### PR TITLE
Add current score to embed, display due up on 3rd out, indicate barrels

### DIFF
--- a/modules/current-play-processor.js
+++ b/modules/current-play-processor.js
@@ -38,11 +38,16 @@ module.exports = {
                 }
             }
         }
+        /* two kinds of objects get processed - "at bats", which will have a "result" object, and events within at bats, which put
+            the same information in a "details" object. So we often have to check for both.
+         */
         return {
             reply,
             isStartEvent: currentPlayJSON.playEvents?.find(event => event?.details?.description === 'Status Change - In Progress'),
-            homeScore: currentPlayJSON.result?.homeScore,
-            awayScore: currentPlayJSON.result?.awayScore,
+            isOut: currentPlayJSON.result?.isOut || currentPlayJSON.details?.isOut,
+            outs: currentPlayJSON.count?.outs,
+            homeScore: (currentPlayJSON.result ? currentPlayJSON.result.homeScore : currentPlayJSON.details?.homeScore),
+            awayScore: (currentPlayJSON.result ? currentPlayJSON.result.awayScore : currentPlayJSON.details?.awayScore),
             isComplete: currentPlayJSON.about?.isComplete,
             description: (currentPlayJSON.result?.description || currentPlayJSON.details?.description),
             event: (currentPlayJSON.result?.event || currentPlayJSON.details?.event),
@@ -50,6 +55,7 @@ module.exports = {
             isScoringPlay: (currentPlayJSON.about?.isScoringPlay || currentPlayJSON.details?.isScoringPlay),
             isInPlay: (lastEvent?.details?.isInPlay || currentPlayJSON.details?.isInPlay),
             playId: (lastEvent?.playId || currentPlayJSON.playId),
+            metricsAvailable: (lastEvent?.hitData?.launchSpeed !== undefined || currentPlayJSON.hitData?.launchSpeed !== undefined),
             hitDistance: (lastEvent?.hitData?.totalDistance || currentPlayJSON.hitData?.totalDistance)
         };
     }
@@ -82,15 +88,11 @@ function addMetrics (lastEvent, reply) {
             getFireEmojis(lastEvent.hitData.launchSpeed) + '\n';
         reply += 'Launch Angle: ' + lastEvent.hitData.launchAngle + '° \n';
         reply += 'Distance: ' + lastEvent.hitData.totalDistance + ' ft.\n';
-        reply += 'xBA: Pending...\n';
-        reply += lastEvent.hitData.totalDistance && lastEvent.hitData.totalDistance >= 300 ? 'HR/Park: Pending...' : '';
+        reply += 'xBA: Pending...';
+        reply += lastEvent.hitData.totalDistance && lastEvent.hitData.totalDistance >= 300 ? '\nHR/Park: Pending...' : '';
     } else {
         reply += '\n\n**Statcast Metrics:**\n';
-        reply += 'Exit Velocity: Unavailable\n';
-        reply += 'Launch Angle: Unavailable\n';
-        reply += 'Distance: Unavailable\n';
-        reply += 'xBA: Unavailable\n';
-        reply += 'HR/Park: Unavailable';
+        reply += 'Data was not available.';
     }
 
     return reply;

--- a/modules/current-play-processor.js
+++ b/modules/current-play-processor.js
@@ -1,5 +1,6 @@
 const globalCache = require('./global-cache');
 const globals = require('../config/globals');
+const liveFeed = require('./livefeed');
 
 module.exports = {
     process: (currentPlayJSON) => {
@@ -40,6 +41,8 @@ module.exports = {
         return {
             reply,
             isStartEvent: currentPlayJSON.playEvents?.find(event => event?.details?.description === 'Status Change - In Progress'),
+            homeScore: currentPlayJSON.result?.homeScore,
+            awayScore: currentPlayJSON.result?.awayScore,
             isComplete: currentPlayJSON.about?.isComplete,
             description: (currentPlayJSON.result?.description || currentPlayJSON.details?.description),
             event: (currentPlayJSON.result?.event || currentPlayJSON.details?.event),
@@ -54,6 +57,7 @@ module.exports = {
 
 function addScore (reply, currentPlayJSON) {
     reply += '\n';
+    const feed = liveFeed(globalCache.values.game.currentLiveFeed);
     let homeScore, awayScore;
     if (currentPlayJSON.result) {
         homeScore = currentPlayJSON.result.homeScore;
@@ -62,11 +66,11 @@ function addScore (reply, currentPlayJSON) {
         homeScore = currentPlayJSON.details.homeScore;
         awayScore = currentPlayJSON.details.awayScore;
     }
-    reply += (globalCache.values.game.currentLiveFeed.liveData.plays.currentPlay.about.halfInning === 'top'
-        ? '# _' + globalCache.values.game.currentLiveFeed.gameData.teams.away.abbreviation + ' ' + awayScore + '_, ' +
-        globalCache.values.game.currentLiveFeed.gameData.teams.home.abbreviation + ' ' + homeScore
-        : '# ' + globalCache.values.game.currentLiveFeed.gameData.teams.away.abbreviation + ' ' + awayScore + ', _' +
-        globalCache.values.game.currentLiveFeed.gameData.teams.home.abbreviation + ' ' + homeScore + '_');
+    reply += (feed.halfInning() === 'top'
+        ? '# _' + feed.awayAbbreviation() + ' ' + awayScore + '_, ' +
+        feed.homeAbbreviation() + ' ' + homeScore
+        : '# ' + feed.awayAbbreviation() + ' ' + awayScore + ', _' +
+        feed.homeAbbreviation() + ' ' + homeScore + '_');
 
     return reply;
 }

--- a/modules/current-play-processor.js
+++ b/modules/current-play-processor.js
@@ -63,7 +63,7 @@ module.exports = {
 
 function addScore (reply, currentPlayJSON) {
     reply += '\n';
-    const feed = liveFeed(globalCache.values.game.currentLiveFeed);
+    const feed = liveFeed.init(globalCache.values.game.currentLiveFeed);
     let homeScore, awayScore;
     if (currentPlayJSON.result) {
         homeScore = currentPlayJSON.result.homeScore;

--- a/modules/gameday-util.js
+++ b/modules/gameday-util.js
@@ -9,7 +9,7 @@ module.exports = {
     },
 
     didGameEnd: (homeScore, awayScore) => {
-        const feed = liveFeed(globalCache.values.game.currentLiveFeed);
+        const feed = liveFeed.init(globalCache.values.game.currentLiveFeed);
         return feed.inning() >= 9
             && (
                 (homeScore > awayScore && feed.halfInning() === 'top')
@@ -18,7 +18,7 @@ module.exports = {
     },
 
     getConstrastingEmbedColors: () => {
-        const feed = liveFeed(globalCache.values.game.currentLiveFeed);
+        const feed = liveFeed.init(globalCache.values.game.currentLiveFeed);
         globalCache.values.game.homeTeamColor = globals.TEAMS.find(
             team => team.id === feed.homeTeamId()
         ).primaryColor;
@@ -34,9 +34,9 @@ module.exports = {
     },
 
     getDueUp: () => {
-        const feed = liveFeed(globalCache.values.game.currentLiveFeed);
+        const feed = liveFeed.init(globalCache.values.game.currentLiveFeed);
         const linescore = feed.linescore();
 
-        return '\n\n**Due up**: ' + linescore.offense.batter.fullName + ', ' + linescore.offense.onDeck.fullName + ', ' + linescore.offense.inHole.fullName;
+        return '\n\n**Due up**: ' + linescore.offense?.batter?.fullName + ', ' + linescore.offense?.onDeck?.fullName + ', ' + linescore.offense?.inHole?.fullName;
     }
-}
+};

--- a/modules/gameday-util.js
+++ b/modules/gameday-util.js
@@ -1,0 +1,42 @@
+const liveFeed = require('./livefeed');
+const globalCache = require('./global-cache');
+const globals = require('../config/globals');
+const ColorContrastChecker = require('color-contrast-checker');
+
+module.exports = {
+    deriveHalfInning: (halfInningFull) => {
+        return halfInningFull === 'top' ? 'TOP' : 'BOT';
+    },
+
+    didGameEnd: (homeScore, awayScore) => {
+        const feed = liveFeed(globalCache.values.game.currentLiveFeed);
+        return feed.inning() >= 9
+            && (
+                (homeScore > awayScore && feed.halfInning() === 'top')
+                || (awayScore > homeScore && feed.halfInning() === 'bottom')
+            );
+    },
+
+    getConstrastingEmbedColors: () => {
+        const feed = liveFeed(globalCache.values.game.currentLiveFeed);
+        globalCache.values.game.homeTeamColor = globals.TEAMS.find(
+            team => team.id === feed.homeTeamId()
+        ).primaryColor;
+        const awayTeam = globals.TEAMS.find(
+            team => team.id === feed.awayTeamId()
+        );
+        const colorContrastChecker = new ColorContrastChecker();
+        if (colorContrastChecker.isLevelCustom(globalCache.values.game.homeTeamColor, awayTeam.primaryColor, globals.TEAM_COLOR_CONTRAST_RATIO)) {
+            globalCache.values.game.awayTeamColor = awayTeam.primaryColor;
+        } else {
+            globalCache.values.game.awayTeamColor = awayTeam.secondaryColor;
+        }
+    },
+
+    getDueUp: () => {
+        const feed = liveFeed(globalCache.values.game.currentLiveFeed);
+        const linescore = feed.linescore();
+
+        return '\n\n**Due up**: ' + linescore.offense.batter.fullName + ', ' + linescore.offense.onDeck.fullName + ', ' + linescore.offense.inHole.fullName;
+    }
+}

--- a/modules/gameday.js
+++ b/modules/gameday.js
@@ -104,7 +104,7 @@ function subscribe (bot, liveGame, games) {
 }
 
 async function reportPlays (bot, gamePk) {
-    const feed = liveFeed(globalCache.values.game.currentLiveFeed);
+    const feed = liveFeed.init(globalCache.values.game.currentLiveFeed);
     const currentPlay = feed.currentPlay();
     const atBatIndex = currentPlay.atBatIndex;
     const lastReportedCompleteAtBatIndex = globalCache.values.game.lastReportedCompleteAtBatIndex;
@@ -141,7 +141,7 @@ async function processAndPushPlay (bot, play, gamePk, atBatIndex) {
         && !globalCache.values.game.reportedDescriptions
             .find(reportedDescription => reportedDescription.description === play.description && reportedDescription.atBatIndex === atBatIndex)) {
         globalCache.values.game.reportedDescriptions.push({ description: play.description, atBatIndex });
-        const feed = liveFeed(globalCache.values.game.currentLiveFeed);
+        const feed = liveFeed.init(globalCache.values.game.currentLiveFeed);
         if (play.isComplete) {
             globalCache.values.game.lastReportedCompleteAtBatIndex = atBatIndex;
         }

--- a/modules/livefeed.js
+++ b/modules/livefeed.js
@@ -1,0 +1,14 @@
+module.exports = (liveFeed) => {
+    return {
+        timestamp: () => { return liveFeed.metaData.timeStamp; },
+        inning: () => { return liveFeed.liveData.plays.currentPlay.about.inning; },
+        halfInning: () => { return liveFeed.liveData.plays.currentPlay.about.halfInning; },
+        awayAbbreviation: () => { return liveFeed.gameData.teams.away.abbreviation; },
+        homeAbbreviation: () => { return liveFeed.gameData.teams.home.abbreviation; },
+        homeTeamId: () => { return liveFeed.gameData.teams.home.id; },
+        awayTeamId: () => { return liveFeed.gameData.teams.away.id; },
+        currentPlay: () => { return liveFeed.liveData.plays.currentPlay; },
+        allPlays: () => { return liveFeed.liveData.plays.allPlays; }
+
+    };
+};

--- a/modules/livefeed.js
+++ b/modules/livefeed.js
@@ -8,7 +8,7 @@ module.exports = (liveFeed) => {
         homeTeamId: () => { return liveFeed.gameData.teams.home.id; },
         awayTeamId: () => { return liveFeed.gameData.teams.away.id; },
         currentPlay: () => { return liveFeed.liveData.plays.currentPlay; },
-        allPlays: () => { return liveFeed.liveData.plays.allPlays; }
-
+        allPlays: () => { return liveFeed.liveData.plays.allPlays; },
+        linescore: () => { return liveFeed.liveData.linescore; }
     };
 };

--- a/modules/livefeed.js
+++ b/modules/livefeed.js
@@ -1,14 +1,36 @@
-module.exports = (liveFeed) => {
-    return {
-        timestamp: () => { return liveFeed.metaData.timeStamp; },
-        inning: () => { return liveFeed.liveData.plays.currentPlay.about.inning; },
-        halfInning: () => { return liveFeed.liveData.plays.currentPlay.about.halfInning; },
-        awayAbbreviation: () => { return liveFeed.gameData.teams.away.abbreviation; },
-        homeAbbreviation: () => { return liveFeed.gameData.teams.home.abbreviation; },
-        homeTeamId: () => { return liveFeed.gameData.teams.home.id; },
-        awayTeamId: () => { return liveFeed.gameData.teams.away.id; },
-        currentPlay: () => { return liveFeed.liveData.plays.currentPlay; },
-        allPlays: () => { return liveFeed.liveData.plays.allPlays; },
-        linescore: () => { return liveFeed.liveData.linescore; }
-    };
+module.exports = {
+    init: (liveFeed) => {
+        return {
+            timestamp: () => {
+                return liveFeed.metaData.timeStamp;
+            },
+            inning: () => {
+                return liveFeed.liveData.plays.currentPlay.about.inning;
+            },
+            halfInning: () => {
+                return liveFeed.liveData.plays.currentPlay.about.halfInning;
+            },
+            awayAbbreviation: () => {
+                return liveFeed.gameData.teams.away.abbreviation;
+            },
+            homeAbbreviation: () => {
+                return liveFeed.gameData.teams.home.abbreviation;
+            },
+            homeTeamId: () => {
+                return liveFeed.gameData.teams.home.id;
+            },
+            awayTeamId: () => {
+                return liveFeed.gameData.teams.away.id;
+            },
+            currentPlay: () => {
+                return liveFeed.liveData.plays.currentPlay;
+            },
+            allPlays: () => {
+                return liveFeed.liveData.plays.allPlays;
+            },
+            linescore: () => {
+                return liveFeed.liveData.linescore;
+            }
+        };
+    }
 };

--- a/spec/command-util-spec.js
+++ b/spec/command-util-spec.js
@@ -1,6 +1,6 @@
 const commandUtil = require('../modules/command-util');
 
-describe('commandUtil', () => {
+describe('command-util', () => {
     beforeAll(() => {});
     describe('#formatSplits', () => {
         it('should format splits for a player that has played on multiple teams in a season', async () => {

--- a/spec/current-play-processor-spec.js
+++ b/spec/current-play-processor-spec.js
@@ -2,7 +2,7 @@ const currentPlayProcessor = require('../modules/current-play-processor');
 const globalCache = require('../modules/global-cache');
 const examplePlays = require('./data/example-plays');
 
-describe('currentPlayProcessor', () => {
+describe('current-play-processor', () => {
     beforeAll(() => {
         globalCache.values.game.currentLiveFeed = require('./data/example-live-feed');
     });

--- a/spec/diff-patch-spec.js
+++ b/spec/diff-patch-spec.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const globalCache = require('../modules/global-cache');
 const path = require('path');
 
-describe('diffPatch', () => {
+describe('diff-patch', () => {
     let diff;
 
     beforeAll(() => {

--- a/spec/gameday-spec.js
+++ b/spec/gameday-spec.js
@@ -1,4 +1,5 @@
 const gameday = require('../modules/gameday');
+const gamedayUtil = require('../modules/gameday-util')
 const mlbAPIUtil = require('../modules/MLB-API-util');
 const globals = require('../config/globals');
 const mockResponses = require('./data/mock-responses');
@@ -8,7 +9,7 @@ const { EmbedBuilder } = require('discord.js');
 describe('gameday', () => {
     describe('#statusPoll', () => {
         beforeEach(() => {
-            spyOn(gameday, 'getConstrastingEmbedColors').and.stub();
+            spyOn(gamedayUtil, 'getConstrastingEmbedColors').and.stub();
             spyOn(mlbAPIUtil, 'liveFeed').and.callFake((gamePk, fields) => {
                 return {};
             });
@@ -23,7 +24,7 @@ describe('gameday', () => {
             expect(gameday.subscribe).toHaveBeenCalled();
             expect(mlbAPIUtil.liveFeed).toHaveBeenCalled();
             expect(globalCache.resetGameCache).toHaveBeenCalled();
-            expect(gameday.getConstrastingEmbedColors).toHaveBeenCalled();
+            expect(gamedayUtil.getConstrastingEmbedColors).toHaveBeenCalled();
         });
 
         it('should continue polling if no game is live', async () => {
@@ -39,7 +40,7 @@ describe('gameday', () => {
             expect(gameday.subscribe).not.toHaveBeenCalled();
             expect(mlbAPIUtil.liveFeed).not.toHaveBeenCalled();
             expect(globalCache.resetGameCache).not.toHaveBeenCalled();
-            expect(gameday.getConstrastingEmbedColors).not.toHaveBeenCalled();
+            expect(gamedayUtil.getConstrastingEmbedColors).not.toHaveBeenCalled();
             jasmine.clock().uninstall();
         });
     });

--- a/spec/gameday-spec.js
+++ b/spec/gameday-spec.js
@@ -1,5 +1,5 @@
 const gameday = require('../modules/gameday');
-const gamedayUtil = require('../modules/gameday-util')
+const gamedayUtil = require('../modules/gameday-util');
 const mlbAPIUtil = require('../modules/MLB-API-util');
 const globals = require('../config/globals');
 const mockResponses = require('./data/mock-responses');

--- a/spec/gameday-util-spec.js
+++ b/spec/gameday-util-spec.js
@@ -1,0 +1,48 @@
+const gamedayUtil = require('../modules/gameday-util');
+const liveFeed = require('../modules/livefeed');
+
+describe('gameday-util', () => {
+    beforeAll(() => {});
+
+    describe('#didGameEnd', () => {
+        it('should say the game ended when the top of the 9th ended with the home team leading', async () => {
+            spyOn(liveFeed, 'init').and.returnValue({
+                inning: () => { return 9; },
+                halfInning: () => { return 'top'; }
+            });
+            expect(gamedayUtil.didGameEnd(3, 2)).toBeTrue();
+        });
+
+        it('should say the game ended when the bottom of the 9th ended with the away team leading', async () => {
+            spyOn(liveFeed, 'init').and.returnValue({
+                inning: () => { return 9; },
+                halfInning: () => { return 'bottom'; }
+            });
+            expect(gamedayUtil.didGameEnd(2, 3)).toBeTrue();
+        });
+
+        it('should say the game is still going if the game is tied', async () => {
+            spyOn(liveFeed, 'init').and.returnValue({
+                inning: () => { return 9; },
+                halfInning: () => { return 'bottom'; }
+            });
+            expect(gamedayUtil.didGameEnd(3, 3)).toBeFalse();
+        });
+
+        it('should say the game is still going the top of the 9th has ended with the away team leading', async () => {
+            spyOn(liveFeed, 'init').and.returnValue({
+                inning: () => { return 9; },
+                halfInning: () => { return 'top'; }
+            });
+            expect(gamedayUtil.didGameEnd(3, 10)).toBeFalse();
+        });
+
+        it('should say the game ended when the top of an extra inning ended with the home team leading', async () => {
+            spyOn(liveFeed, 'init').and.returnValue({
+                inning: () => { return 15; },
+                halfInning: () => { return 'top'; }
+            });
+            expect(gamedayUtil.didGameEnd(3, 2)).toBeTrue();
+        });
+    });
+});


### PR DESCRIPTION
implements #21 , #20

- display the score on the embed header always. When it's a scoring play, omit it from the header.

![image](https://github.com/user-attachments/assets/e6f0e76c-757d-4de7-9b21-b75f407f95a3)

- for the third out of a half inning (that is not the end of the game), display who is due up.

![image](https://github.com/user-attachments/assets/6095b5b5-625f-4313-ad06-850c14ab1994)

- for balls that are [barrels](https://www.mlb.com/glossary/statcast/barrel), indicate so.

![image](https://github.com/user-attachments/assets/9741b279-76a1-48b5-8d9e-ab152cf15f79)

