### PR TITLE
List exceptional HR/Park scenarios

### DIFF
--- a/config/globals.js
+++ b/config/globals.js
@@ -1,29 +1,4 @@
 module.exports = {
-    EVENT_BLACKLIST: [
-        "batter_timeout",
-        "mound_visit",
-        "offensive_substitution",
-        "defensive_switch",
-        "foul",
-        "ball",
-        "called_strike",
-        "swinging_strike",
-        "swinging_strike_blocked",
-        "hit_into_play",
-        "pickoff_1b",
-        "pickoff_2b",
-        "pickoff_3b",
-        "hit_into_play_no_out",
-        "foul_tip",
-        "at_bat_start",
-        "blocked_ball",
-        "defensive_indiff",
-        "pitcher_step_off",
-        "no_pitch",
-        "ejection",
-        "injury",
-        "umpire_substitution"
-    ],
     EVENT_WHITELIST:[
         'pickoff_1b',
         'pickoff_2b',
@@ -95,6 +70,8 @@ module.exports = {
     DATE: null,
     ADMIN_ROLES: [ "Mod" ],
     TEAM_COLOR_CONTRAST_RATIO: 1.5,
+    HOME_RUN_PARKS_MIN: 30,
+    HOME_RUN_PARKS_MAX: 1,
     EVENTS: [
         "Double",
         "Double Play",

--- a/config/globals.js
+++ b/config/globals.js
@@ -70,8 +70,8 @@ module.exports = {
     DATE: null,
     ADMIN_ROLES: [ "Mod" ],
     TEAM_COLOR_CONTRAST_RATIO: 1.5,
-    HOME_RUN_PARKS_MIN: 30,
-    HOME_RUN_PARKS_MAX: 1,
+    HOME_RUN_PARKS_MIN: 4,
+    HOME_RUN_PARKS_MAX: 26,
     EVENTS: [
         "Double",
         "Double Play",

--- a/modules/gameday-util.js
+++ b/modules/gameday-util.js
@@ -2,6 +2,7 @@ const liveFeed = require('./livefeed');
 const globalCache = require('./global-cache');
 const globals = require('../config/globals');
 const ColorContrastChecker = require('color-contrast-checker');
+const mlbAPIUtil = require("./MLB-API-util");
 
 module.exports = {
     deriveHalfInning: (halfInningFull) => {
@@ -38,5 +39,20 @@ module.exports = {
         const linescore = feed.linescore();
 
         return '\n\n**Due up**: ' + linescore.offense?.batter?.fullName + ', ' + linescore.offense?.onDeck?.fullName + ', ' + linescore.offense?.inHole?.fullName;
+    },
+
+    getXParks: async (gamePk, playId, numberOfParks) => {
+        let reply = ' - ';
+        const xParks = await mlbAPIUtil.xParks(gamePk, playId);
+
+        let parks = numberOfParks >= globals.HOME_RUN_PARKS_MAX ? xParks.not : xParks.hr
+
+        for (let i = 0; i < parks.length; i ++) {
+            reply += parks[i].name + ' (' + parks[i].team_abbrev + ')'
+            if (i < parks.length - 1) {
+                reply += ', '
+            }
+        }
+        return reply;
     }
 };

--- a/modules/gameday-util.js
+++ b/modules/gameday-util.js
@@ -2,7 +2,7 @@ const liveFeed = require('./livefeed');
 const globalCache = require('./global-cache');
 const globals = require('../config/globals');
 const ColorContrastChecker = require('color-contrast-checker');
-const mlbAPIUtil = require("./MLB-API-util");
+const mlbAPIUtil = require('./MLB-API-util');
 
 module.exports = {
     deriveHalfInning: (halfInningFull) => {
@@ -42,17 +42,38 @@ module.exports = {
     },
 
     getXParks: async (gamePk, playId, numberOfParks) => {
-        let reply = ' - ';
-        const xParks = await mlbAPIUtil.xParks(gamePk, playId);
-
-        let parks = numberOfParks >= globals.HOME_RUN_PARKS_MAX ? xParks.not : xParks.hr
-
-        for (let i = 0; i < parks.length; i ++) {
-            reply += parks[i].name + ' (' + parks[i].team_abbrev + ')'
-            if (i < parks.length - 1) {
-                reply += ', '
-            }
+        const feed = liveFeed.init(globalCache.values.game.currentLiveFeed);
+        const isHome = feed.homeTeamId() === process.env.TEAM_ID;
+        let reply = '';
+        if (numberOfParks === 0 || numberOfParks === 30) {
+            return reply;
         }
+        let xParks;
+        try {
+            xParks = await mlbAPIUtil.xParks(gamePk, playId);
+        } catch (e) {
+            console.error(e);
+            return reply;
+        }
+        if (numberOfParks <= globals.HOME_RUN_PARKS_MIN || numberOfParks >= globals.HOME_RUN_PARKS_MAX) {
+            reply += ' - ';
+            const parks = numberOfParks >= globals.HOME_RUN_PARKS_MAX ? xParks.not : xParks.hr;
+            for (let i = 0; i < parks.length; i ++) {
+                reply += parks[i].name + ' (' + parks[i].team_abbrev + ')';
+                if (i < parks.length - 1) {
+                    reply += ', ';
+                }
+            }
+            return reply;
+        } else if (!isHome) {
+            if (xParks.hr.find(park => park.id === feed.awayTeamVenue().id)) {
+                reply += ', including ' + feed.awayTeamVenue().name;
+            } else if (xParks.not.find(park => park.id === feed.awayTeamVenue().id)) {
+                reply += ', but not ' + feed.awayTeamVenue().name;
+            }
+            return reply;
+        }
+
         return reply;
     }
 };

--- a/modules/gameday.js
+++ b/modules/gameday.js
@@ -256,7 +256,8 @@ async function pollForSavantData (gamePk, playId, messages, hitDistance) {
     await pollingFunction();
 }
 
-function processMatchingPlay (matchingPlay, messages, messageTrackers, playId, hitDistance) {
+async function processMatchingPlay (matchingPlay, messages, messageTrackers, playId, hitDistance) {
+    const feed = liveFeed.init(globalCache.values.game.currentLiveFeed);
     for (let i = 0; i < messages.length; i ++) {
         const receivedEmbed = EmbedBuilder.from(messages[i].embeds[0]);
         let description = messages[i].embeds[0].description;
@@ -277,9 +278,13 @@ function processMatchingPlay (matchingPlay, messages, messageTrackers, playId, h
             && matchingPlay.contextMetrics.homeRunBallparks !== undefined
             && description.includes('HR/Park: Pending...')) {
             LOGGER.debug('Editing with HR/Park: ' + playId);
-            description = description.replaceAll('HR/Park: Pending...', 'HR/Park: ' +
+            const homeRunBallParksDescription = 'HR/Park: ' +
                 matchingPlay.contextMetrics.homeRunBallparks + '/30' +
-                (matchingPlay.contextMetrics.homeRunBallparks === 30 ? '\u203C\uFE0F' : ''));
+                (matchingPlay.contextMetrics.homeRunBallparks === 30 ? '\u203C\uFE0F' : '')
+                + (matchingPlay.contextMetrics.homeRunBallparks <= globals.HOME_RUN_PARKS_MIN || matchingPlay.contextMetrics.homeRunBallparks >= globals.HOME_RUN_PARKS_MAX
+                    ? (await gamedayUtil.getXParks(feed.gamePk(), playId, matchingPlay.contextMetrics.homeRunBallparks))
+                    : '')
+            description = description.replaceAll('HR/Park: Pending...', homeRunBallParksDescription);
             receivedEmbed.setDescription(description);
             messages[i].edit({
                 embeds: [receivedEmbed]

--- a/modules/gameday.js
+++ b/modules/gameday.js
@@ -278,12 +278,9 @@ async function processMatchingPlay (matchingPlay, messages, messageTrackers, pla
             && matchingPlay.contextMetrics.homeRunBallparks !== undefined
             && description.includes('HR/Park: Pending...')) {
             LOGGER.debug('Editing with HR/Park: ' + playId);
-            const homeRunBallParksDescription = 'HR/Park: ' +
-                matchingPlay.contextMetrics.homeRunBallparks + '/30' +
-                (matchingPlay.contextMetrics.homeRunBallparks === 30 ? '\u203C\uFE0F' : '')
-                + (matchingPlay.contextMetrics.homeRunBallparks <= globals.HOME_RUN_PARKS_MIN || matchingPlay.contextMetrics.homeRunBallparks >= globals.HOME_RUN_PARKS_MAX
-                    ? (await gamedayUtil.getXParks(feed.gamePk(), playId, matchingPlay.contextMetrics.homeRunBallparks))
-                    : '')
+            const homeRunBallParksDescription = 'HR/Park: ' + matchingPlay.contextMetrics.homeRunBallparks + '/30' +
+                (matchingPlay.contextMetrics.homeRunBallparks === 30 ? '\u203C\uFE0F' : '') +
+                (await gamedayUtil.getXParks(feed.gamePk(), playId, matchingPlay.contextMetrics.homeRunBallparks));
             description = description.replaceAll('HR/Park: Pending...', homeRunBallParksDescription);
             receivedEmbed.setDescription(description);
             messages[i].edit({

--- a/modules/livefeed.js
+++ b/modules/livefeed.js
@@ -1,6 +1,9 @@
 module.exports = {
     init: (liveFeed) => {
         return {
+            gamePk: () => {
+                return liveFeed.gameData.game.pk;
+            },
             timestamp: () => {
                 return liveFeed.metaData.timeStamp;
             },

--- a/modules/livefeed.js
+++ b/modules/livefeed.js
@@ -25,6 +25,12 @@ module.exports = {
             awayTeamId: () => {
                 return liveFeed.gameData.teams.away.id;
             },
+            homeTeamVenue: () => {
+                return liveFeed.gameData.teams.home.venue;
+            },
+            awayTeamVenue: () => {
+                return liveFeed.gameData.teams.away.venue;
+            },
             currentPlay: () => {
                 return liveFeed.liveData.plays.currentPlay;
             },

--- a/spec/data/mock-responses.js
+++ b/spec/data/mock-responses.js
@@ -82,5 +82,743 @@ module.exports = {
         team_away: [
             { play_id: 'abc', xba: '.520' }
         ]
+    },
+    xParksOnePark: {
+        hr: [
+            {
+                id: 3313,
+                name: 'Yankee Stadium',
+                season: '2024',
+                team_id: 147,
+                name_display_club: 'Yankees',
+                team_abbrev: 'NYY'
+            }
+        ],
+        not: [
+            {
+                id: 15,
+                name: 'Chase Field',
+                season: '2024',
+                team_id: 109,
+                name_display_club: 'D-backs',
+                team_abbrev: 'ARI'
+            },
+            {
+                id: 4705,
+                name: 'Truist Park',
+                season: '2024',
+                team_id: 144,
+                name_display_club: 'Braves',
+                team_abbrev: 'ATL'
+            },
+            {
+                id: 2,
+                name: 'Oriole Park at Camden Yards',
+                season: '2024',
+                team_id: 110,
+                name_display_club: 'Orioles',
+                team_abbrev: 'BAL'
+            },
+            {
+                id: 3,
+                name: 'Fenway Park',
+                season: '2024',
+                team_id: 111,
+                name_display_club: 'Red Sox',
+                team_abbrev: 'BOS'
+            },
+            {
+                id: 17,
+                name: 'Wrigley Field',
+                season: '2024',
+                team_id: 112,
+                name_display_club: 'Cubs',
+                team_abbrev: 'CHC'
+            },
+            {
+                id: 2602,
+                name: 'Great American Ball Park',
+                season: '2024',
+                team_id: 113,
+                name_display_club: 'Reds',
+                team_abbrev: 'CIN'
+            },
+            {
+                id: 5,
+                name: 'Progressive Field',
+                season: '2024',
+                team_id: 114,
+                name_display_club: 'Guardians',
+                team_abbrev: 'CLE'
+            },
+            {
+                id: 19,
+                name: 'Coors Field',
+                season: '2024',
+                team_id: 115,
+                name_display_club: 'Rockies',
+                team_abbrev: 'COL'
+            },
+            {
+                id: 4,
+                name: 'Guaranteed Rate Field',
+                season: '2024',
+                team_id: 145,
+                name_display_club: 'White Sox',
+                team_abbrev: 'CWS'
+            },
+            {
+                id: 2394,
+                name: 'Comerica Park',
+                season: '2024',
+                team_id: 116,
+                name_display_club: 'Tigers',
+                team_abbrev: 'DET'
+            },
+            {
+                id: 2392,
+                name: 'Minute Maid Park',
+                season: '2024',
+                team_id: 117,
+                name_display_club: 'Astros',
+                team_abbrev: 'HOU'
+            },
+            {
+                id: 7,
+                name: 'Kauffman Stadium',
+                season: '2024',
+                team_id: 118,
+                name_display_club: 'Royals',
+                team_abbrev: 'KC'
+            },
+            {
+                id: 1,
+                name: 'Angel Stadium',
+                season: '2024',
+                team_id: 108,
+                name_display_club: 'Angels',
+                team_abbrev: 'LAA'
+            },
+            {
+                id: 22,
+                name: 'Dodger Stadium',
+                season: '2024',
+                team_id: 119,
+                name_display_club: 'Dodgers',
+                team_abbrev: 'LAD'
+            },
+            {
+                id: 4169,
+                name: 'loanDepot park',
+                season: '2024',
+                team_id: 146,
+                name_display_club: 'Marlins',
+                team_abbrev: 'MIA'
+            },
+            {
+                id: 32,
+                name: 'American Family Field',
+                season: '2024',
+                team_id: 158,
+                name_display_club: 'Brewers',
+                team_abbrev: 'MIL'
+            },
+            {
+                id: 3312,
+                name: 'Target Field',
+                season: '2024',
+                team_id: 142,
+                name_display_club: 'Twins',
+                team_abbrev: 'MIN'
+            },
+            {
+                id: 3289,
+                name: 'Citi Field',
+                season: '2024',
+                team_id: 121,
+                name_display_club: 'Mets',
+                team_abbrev: 'NYM'
+            },
+            {
+                id: 10,
+                name: 'Oakland Coliseum',
+                season: '2024',
+                team_id: 133,
+                name_display_club: 'Athletics',
+                team_abbrev: 'OAK'
+            },
+            {
+                id: 2681,
+                name: 'Citizens Bank Park',
+                season: '2024',
+                team_id: 143,
+                name_display_club: 'Phillies',
+                team_abbrev: 'PHI'
+            },
+            {
+                id: 31,
+                name: 'PNC Park',
+                season: '2024',
+                team_id: 134,
+                name_display_club: 'Pirates',
+                team_abbrev: 'PIT'
+            },
+            {
+                id: 2680,
+                name: 'Petco Park',
+                season: '2024',
+                team_id: 135,
+                name_display_club: 'Padres',
+                team_abbrev: 'SD'
+            },
+            {
+                id: 680,
+                name: 'T-Mobile Park',
+                season: '2024',
+                team_id: 136,
+                name_display_club: 'Mariners',
+                team_abbrev: 'SEA'
+            },
+            {
+                id: 2395,
+                name: 'Oracle Park',
+                season: '2024',
+                team_id: 137,
+                name_display_club: 'Giants',
+                team_abbrev: 'SF'
+            },
+            {
+                id: 2889,
+                name: 'Busch Stadium',
+                season: '2024',
+                team_id: 138,
+                name_display_club: 'Cardinals',
+                team_abbrev: 'STL'
+            },
+            {
+                id: 12,
+                name: 'Tropicana Field',
+                season: '2024',
+                team_id: 139,
+                name_display_club: 'Rays',
+                team_abbrev: 'TB'
+            },
+            {
+                id: 5325,
+                name: 'Globe Life Field',
+                season: '2024',
+                team_id: 140,
+                name_display_club: 'Rangers',
+                team_abbrev: 'TEX'
+            },
+            {
+                id: 14,
+                name: 'Rogers Centre',
+                season: '2024',
+                team_id: 141,
+                name_display_club: 'Blue Jays',
+                team_abbrev: 'TOR'
+            },
+            {
+                id: 3309,
+                name: 'Nationals Park',
+                season: '2024',
+                team_id: 120,
+                name_display_club: 'Nationals',
+                team_abbrev: 'WSH'
+            }
+        ]
+    },
+    xParksAllButOne: {
+        hr: [
+            {
+                id: 15,
+                name: 'Chase Field',
+                season: '2024',
+                team_id: 109,
+                name_display_club: 'D-backs',
+                team_abbrev: 'ARI'
+            },
+            {
+                id: 4705,
+                name: 'Truist Park',
+                season: '2024',
+                team_id: 144,
+                name_display_club: 'Braves',
+                team_abbrev: 'ATL'
+            },
+            {
+                id: 2,
+                name: 'Oriole Park at Camden Yards',
+                season: '2024',
+                team_id: 110,
+                name_display_club: 'Orioles',
+                team_abbrev: 'BAL'
+            },
+            {
+                id: 17,
+                name: 'Wrigley Field',
+                season: '2024',
+                team_id: 112,
+                name_display_club: 'Cubs',
+                team_abbrev: 'CHC'
+            },
+            {
+                id: 2602,
+                name: 'Great American Ball Park',
+                season: '2024',
+                team_id: 113,
+                name_display_club: 'Reds',
+                team_abbrev: 'CIN'
+            },
+            {
+                id: 5,
+                name: 'Progressive Field',
+                season: '2024',
+                team_id: 114,
+                name_display_club: 'Guardians',
+                team_abbrev: 'CLE'
+            },
+            {
+                id: 19,
+                name: 'Coors Field',
+                season: '2024',
+                team_id: 115,
+                name_display_club: 'Rockies',
+                team_abbrev: 'COL'
+            },
+            {
+                id: 4,
+                name: 'Guaranteed Rate Field',
+                season: '2024',
+                team_id: 145,
+                name_display_club: 'White Sox',
+                team_abbrev: 'CWS'
+            },
+            {
+                id: 2394,
+                name: 'Comerica Park',
+                season: '2024',
+                team_id: 116,
+                name_display_club: 'Tigers',
+                team_abbrev: 'DET'
+            },
+            {
+                id: 2392,
+                name: 'Minute Maid Park',
+                season: '2024',
+                team_id: 117,
+                name_display_club: 'Astros',
+                team_abbrev: 'HOU'
+            },
+            {
+                id: 7,
+                name: 'Kauffman Stadium',
+                season: '2024',
+                team_id: 118,
+                name_display_club: 'Royals',
+                team_abbrev: 'KC'
+            },
+            {
+                id: 1,
+                name: 'Angel Stadium',
+                season: '2024',
+                team_id: 108,
+                name_display_club: 'Angels',
+                team_abbrev: 'LAA'
+            },
+            {
+                id: 22,
+                name: 'Dodger Stadium',
+                season: '2024',
+                team_id: 119,
+                name_display_club: 'Dodgers',
+                team_abbrev: 'LAD'
+            },
+            {
+                id: 4169,
+                name: 'loanDepot park',
+                season: '2024',
+                team_id: 146,
+                name_display_club: 'Marlins',
+                team_abbrev: 'MIA'
+            },
+            {
+                id: 32,
+                name: 'American Family Field',
+                season: '2024',
+                team_id: 158,
+                name_display_club: 'Brewers',
+                team_abbrev: 'MIL'
+            },
+            {
+                id: 3312,
+                name: 'Target Field',
+                season: '2024',
+                team_id: 142,
+                name_display_club: 'Twins',
+                team_abbrev: 'MIN'
+            },
+            {
+                id: 3289,
+                name: 'Citi Field',
+                season: '2024',
+                team_id: 121,
+                name_display_club: 'Mets',
+                team_abbrev: 'NYM'
+            },
+            {
+                id: 3313,
+                name: 'Yankee Stadium',
+                season: '2024',
+                team_id: 147,
+                name_display_club: 'Yankees',
+                team_abbrev: 'NYY'
+            },
+            {
+                id: 10,
+                name: 'Oakland Coliseum',
+                season: '2024',
+                team_id: 133,
+                name_display_club: 'Athletics',
+                team_abbrev: 'OAK'
+            },
+            {
+                id: 2681,
+                name: 'Citizens Bank Park',
+                season: '2024',
+                team_id: 143,
+                name_display_club: 'Phillies',
+                team_abbrev: 'PHI'
+            },
+            {
+                id: 31,
+                name: 'PNC Park',
+                season: '2024',
+                team_id: 134,
+                name_display_club: 'Pirates',
+                team_abbrev: 'PIT'
+            },
+            {
+                id: 2680,
+                name: 'Petco Park',
+                season: '2024',
+                team_id: 135,
+                name_display_club: 'Padres',
+                team_abbrev: 'SD'
+            },
+            {
+                id: 680,
+                name: 'T-Mobile Park',
+                season: '2024',
+                team_id: 136,
+                name_display_club: 'Mariners',
+                team_abbrev: 'SEA'
+            },
+            {
+                id: 2395,
+                name: 'Oracle Park',
+                season: '2024',
+                team_id: 137,
+                name_display_club: 'Giants',
+                team_abbrev: 'SF'
+            },
+            {
+                id: 2889,
+                name: 'Busch Stadium',
+                season: '2024',
+                team_id: 138,
+                name_display_club: 'Cardinals',
+                team_abbrev: 'STL'
+            },
+            {
+                id: 12,
+                name: 'Tropicana Field',
+                season: '2024',
+                team_id: 139,
+                name_display_club: 'Rays',
+                team_abbrev: 'TB'
+            },
+            {
+                id: 5325,
+                name: 'Globe Life Field',
+                season: '2024',
+                team_id: 140,
+                name_display_club: 'Rangers',
+                team_abbrev: 'TEX'
+            },
+            {
+                id: 14,
+                name: 'Rogers Centre',
+                season: '2024',
+                team_id: 141,
+                name_display_club: 'Blue Jays',
+                team_abbrev: 'TOR'
+            },
+            {
+                id: 3309,
+                name: 'Nationals Park',
+                season: '2024',
+                team_id: 120,
+                name_display_club: 'Nationals',
+                team_abbrev: 'WSH'
+            }
+        ],
+        not: [
+            {
+                id: 3,
+                name: 'Fenway Park',
+                season: '2024',
+                team_id: 111,
+                name_display_club: 'Red Sox',
+                team_abbrev: 'BOS'
+            }
+        ]
+    },
+    xParksSomeParks: {
+        hr: [
+            {
+                id: 2602,
+                name: 'Great American Ball Park',
+                season: '2024',
+                team_id: 113,
+                name_display_club: 'Reds',
+                team_abbrev: 'CIN'
+            },
+            {
+                id: 5,
+                name: 'Progressive Field',
+                season: '2024',
+                team_id: 114,
+                name_display_club: 'Guardians',
+                team_abbrev: 'CLE'
+            },
+            {
+                id: 1,
+                name: 'Angel Stadium',
+                season: '2024',
+                team_id: 108,
+                name_display_club: 'Angels',
+                team_abbrev: 'LAA'
+            },
+            {
+                id: 22,
+                name: 'Dodger Stadium',
+                season: '2024',
+                team_id: 119,
+                name_display_club: 'Dodgers',
+                team_abbrev: 'LAD'
+            }
+        ],
+        not: [
+            {
+                id: 15,
+                name: 'Chase Field',
+                season: '2024',
+                team_id: 109,
+                name_display_club: 'D-backs',
+                team_abbrev: 'ARI'
+            },
+            {
+                id: 4705,
+                name: 'Truist Park',
+                season: '2024',
+                team_id: 144,
+                name_display_club: 'Braves',
+                team_abbrev: 'ATL'
+            },
+            {
+                id: 2,
+                name: 'Oriole Park at Camden Yards',
+                season: '2024',
+                team_id: 110,
+                name_display_club: 'Orioles',
+                team_abbrev: 'BAL'
+            },
+            {
+                id: 3,
+                name: 'Fenway Park',
+                season: '2024',
+                team_id: 111,
+                name_display_club: 'Red Sox',
+                team_abbrev: 'BOS'
+            },
+            {
+                id: 17,
+                name: 'Wrigley Field',
+                season: '2024',
+                team_id: 112,
+                name_display_club: 'Cubs',
+                team_abbrev: 'CHC'
+            },
+            {
+                id: 19,
+                name: 'Coors Field',
+                season: '2024',
+                team_id: 115,
+                name_display_club: 'Rockies',
+                team_abbrev: 'COL'
+            },
+            {
+                id: 4,
+                name: 'Guaranteed Rate Field',
+                season: '2024',
+                team_id: 145,
+                name_display_club: 'White Sox',
+                team_abbrev: 'CWS'
+            },
+            {
+                id: 2394,
+                name: 'Comerica Park',
+                season: '2024',
+                team_id: 116,
+                name_display_club: 'Tigers',
+                team_abbrev: 'DET'
+            },
+            {
+                id: 2392,
+                name: 'Minute Maid Park',
+                season: '2024',
+                team_id: 117,
+                name_display_club: 'Astros',
+                team_abbrev: 'HOU'
+            },
+            {
+                id: 7,
+                name: 'Kauffman Stadium',
+                season: '2024',
+                team_id: 118,
+                name_display_club: 'Royals',
+                team_abbrev: 'KC'
+            },
+            {
+                id: 4169,
+                name: 'loanDepot park',
+                season: '2024',
+                team_id: 146,
+                name_display_club: 'Marlins',
+                team_abbrev: 'MIA'
+            },
+            {
+                id: 32,
+                name: 'American Family Field',
+                season: '2024',
+                team_id: 158,
+                name_display_club: 'Brewers',
+                team_abbrev: 'MIL'
+            },
+            {
+                id: 3312,
+                name: 'Target Field',
+                season: '2024',
+                team_id: 142,
+                name_display_club: 'Twins',
+                team_abbrev: 'MIN'
+            },
+            {
+                id: 3289,
+                name: 'Citi Field',
+                season: '2024',
+                team_id: 121,
+                name_display_club: 'Mets',
+                team_abbrev: 'NYM'
+            },
+            {
+                id: 3313,
+                name: 'Yankee Stadium',
+                season: '2024',
+                team_id: 147,
+                name_display_club: 'Yankees',
+                team_abbrev: 'NYY'
+            },
+            {
+                id: 10,
+                name: 'Oakland Coliseum',
+                season: '2024',
+                team_id: 133,
+                name_display_club: 'Athletics',
+                team_abbrev: 'OAK'
+            },
+            {
+                id: 2681,
+                name: 'Citizens Bank Park',
+                season: '2024',
+                team_id: 143,
+                name_display_club: 'Phillies',
+                team_abbrev: 'PHI'
+            },
+            {
+                id: 31,
+                name: 'PNC Park',
+                season: '2024',
+                team_id: 134,
+                name_display_club: 'Pirates',
+                team_abbrev: 'PIT'
+            },
+            {
+                id: 2680,
+                name: 'Petco Park',
+                season: '2024',
+                team_id: 135,
+                name_display_club: 'Padres',
+                team_abbrev: 'SD'
+            },
+            {
+                id: 680,
+                name: 'T-Mobile Park',
+                season: '2024',
+                team_id: 136,
+                name_display_club: 'Mariners',
+                team_abbrev: 'SEA'
+            },
+            {
+                id: 2395,
+                name: 'Oracle Park',
+                season: '2024',
+                team_id: 137,
+                name_display_club: 'Giants',
+                team_abbrev: 'SF'
+            },
+            {
+                id: 2889,
+                name: 'Busch Stadium',
+                season: '2024',
+                team_id: 138,
+                name_display_club: 'Cardinals',
+                team_abbrev: 'STL'
+            },
+            {
+                id: 12,
+                name: 'Tropicana Field',
+                season: '2024',
+                team_id: 139,
+                name_display_club: 'Rays',
+                team_abbrev: 'TB'
+            },
+            {
+                id: 5325,
+                name: 'Globe Life Field',
+                season: '2024',
+                team_id: 140,
+                name_display_club: 'Rangers',
+                team_abbrev: 'TEX'
+            },
+            {
+                id: 14,
+                name: 'Rogers Centre',
+                season: '2024',
+                team_id: 141,
+                name_display_club: 'Blue Jays',
+                team_abbrev: 'TOR'
+            },
+            {
+                id: 3309,
+                name: 'Nationals Park',
+                season: '2024',
+                team_id: 120,
+                name_display_club: 'Nationals',
+                team_abbrev: 'WSH'
+            }
+        ]
     }
 };

--- a/spec/gameday-spec.js
+++ b/spec/gameday-spec.js
@@ -5,6 +5,7 @@ const globals = require('../config/globals');
 const mockResponses = require('./data/mock-responses');
 const globalCache = require('../modules/global-cache');
 const { EmbedBuilder } = require('discord.js');
+const liveFeed = require('../modules/livefeed');
 
 describe('gameday', () => {
     describe('#statusPoll', () => {
@@ -82,8 +83,14 @@ describe('gameday', () => {
     });
 
     describe('#processMatchingPlay', () => {
-        it('should edit all messages with xBA and mark them as done', async () => {
+        beforeEach(() => {
+            spyOn(liveFeed, 'init').and.returnValue({
+                gamePk: () => { return 77777; }
+            });
+        });
+        it('should edit all messages with xBA and HR/Park and mark them as done', async () => {
             const mockSetDescription = (description) => {};
+            spyOn(gamedayUtil, 'getXParks').and.returnValue('');
             const mockEmbed = {
                 description: 'xBA: Pending...\nHR/Park: Pending...',
                 setDescription: mockSetDescription
@@ -100,7 +107,7 @@ describe('gameday', () => {
             ];
             spyOn(EmbedBuilder, 'from').and.returnValue(mockEmbed);
             spyOn(mockEmbed, 'setDescription').and.callThrough();
-            gameday.processMatchingPlay(
+            await gameday.processMatchingPlay(
                 {
                     play_id: 'abc',
                     xba: '.320',

--- a/spec/gameday-util-spec.js
+++ b/spec/gameday-util-spec.js
@@ -73,25 +73,6 @@ describe('gameday-util', () => {
             expect(reply).toEqual(' - Fenway Park (BOS)');
         });
 
-        it('should mention your team\'s ballpark if they are not the home team', async () => {
-            spyOn(mlbAPIUtil, 'xParks').and.returnValue(Promise.resolve(mockResponses.xParksSomeParks));
-            spyOn(liveFeed, 'init').and.returnValue({
-                homeTeamId: () => { return 113; },
-                awayTeamVenue: () => {
-                    return {
-                        id: 5,
-                        name: 'Progressive Field',
-                        season: '2024',
-                        team_id: 114,
-                        name_display_club: 'Guardians',
-                        team_abbrev: 'CLE'
-                    };
-                }
-            });
-            const reply = await gamedayUtil.getXParks('77777', 'abc', 26);
-            expect(reply).toEqual(', including Progressive Field');
-        });
-
         it('should correctly specify when the parks include your team\'s home ballpark, if they are not the home team', async () => {
             spyOn(mlbAPIUtil, 'xParks').and.returnValue(Promise.resolve(mockResponses.xParksSomeParks));
             spyOn(liveFeed, 'init').and.returnValue({

--- a/spec/gameday-util-spec.js
+++ b/spec/gameday-util-spec.js
@@ -1,5 +1,8 @@
 const gamedayUtil = require('../modules/gameday-util');
 const liveFeed = require('../modules/livefeed');
+const mockResponses = require('./data/mock-responses');
+const mlbAPIUtil = require('../modules/MLB-API-util');
+const globals = require('../config/globals');
 
 describe('gameday-util', () => {
     beforeAll(() => {});
@@ -43,6 +46,88 @@ describe('gameday-util', () => {
                 halfInning: () => { return 'top'; }
             });
             expect(gamedayUtil.didGameEnd(3, 2)).toBeTrue();
+        });
+    });
+
+    describe('#getXParks', () => {
+        beforeAll(() => {
+            process.env.TEAM_ID = 114;
+            globals.HOME_RUN_PARKS_MIN = 2;
+            globals.HOME_RUN_PARKS_MAX = 28;
+        });
+        it('should list all the parks where its a home run if its gone in LESS than the minimum.', async () => {
+            spyOn(mlbAPIUtil, 'xParks').and.returnValue(Promise.resolve(mockResponses.xParksOnePark));
+            spyOn(liveFeed, 'init').and.returnValue({
+                homeTeamId: () => { return 1; }
+            });
+            const reply = await gamedayUtil.getXParks('77777', 'abc', 1);
+            expect(reply).toEqual(' - Yankee Stadium (NYY)');
+        });
+
+        it('should list all the parks where it\'s NOT gone if its gone in MORE than the maximum', async () => {
+            spyOn(mlbAPIUtil, 'xParks').and.returnValue(Promise.resolve(mockResponses.xParksAllButOne));
+            spyOn(liveFeed, 'init').and.returnValue({
+                homeTeamId: () => { return 1; }
+            });
+            const reply = await gamedayUtil.getXParks('77777', 'abc', 29);
+            expect(reply).toEqual(' - Fenway Park (BOS)');
+        });
+
+        it('should mention your team\'s ballpark if they are not the home team', async () => {
+            spyOn(mlbAPIUtil, 'xParks').and.returnValue(Promise.resolve(mockResponses.xParksSomeParks));
+            spyOn(liveFeed, 'init').and.returnValue({
+                homeTeamId: () => { return 113; },
+                awayTeamVenue: () => {
+                    return {
+                        id: 5,
+                        name: 'Progressive Field',
+                        season: '2024',
+                        team_id: 114,
+                        name_display_club: 'Guardians',
+                        team_abbrev: 'CLE'
+                    };
+                }
+            });
+            const reply = await gamedayUtil.getXParks('77777', 'abc', 26);
+            expect(reply).toEqual(', including Progressive Field');
+        });
+
+        it('should correctly specify when the parks include your team\'s home ballpark, if they are not the home team', async () => {
+            spyOn(mlbAPIUtil, 'xParks').and.returnValue(Promise.resolve(mockResponses.xParksSomeParks));
+            spyOn(liveFeed, 'init').and.returnValue({
+                homeTeamId: () => { return 113; },
+                awayTeamVenue: () => {
+                    return {
+                        id: 5,
+                        name: 'Progressive Field',
+                        season: '2024',
+                        team_id: 114,
+                        name_display_club: 'Guardians',
+                        team_abbrev: 'CLE'
+                    };
+                }
+            });
+            const reply = await gamedayUtil.getXParks('77777', 'abc', 26);
+            expect(reply).toEqual(', including Progressive Field');
+        });
+
+        it('should correctly specify when the parks DO NOT include your team\'s home ballpark if they are not the home team', async () => {
+            spyOn(mlbAPIUtil, 'xParks').and.returnValue(Promise.resolve(mockResponses.xParksSomeParks));
+            spyOn(liveFeed, 'init').and.returnValue({
+                homeTeamId: () => { return 109; },
+                awayTeamVenue: () => {
+                    return  {
+                        id: 15,
+                        name: 'Chase Field',
+                        season: '2024',
+                        team_id: 109,
+                        name_display_club: 'D-backs',
+                        team_abbrev: 'ARI'
+                    };
+                }
+            });
+            const reply = await gamedayUtil.getXParks('77777', 'abc', 26);
+            expect(reply).toEqual(', but not Chase Field');
         });
     });
 });

--- a/spec/gameday-util-spec.js
+++ b/spec/gameday-util-spec.js
@@ -110,5 +110,24 @@ describe('gameday-util', () => {
             const reply = await gamedayUtil.getXParks('77777', 'abc', 26);
             expect(reply).toEqual(', but not Chase Field');
         });
+
+        it('should not list anything for 0 or 30 parks', async () => {
+            spyOn(mlbAPIUtil, 'xParks').and.returnValue(Promise.resolve(mockResponses.xParksSomeParks));
+            spyOn(liveFeed, 'init').and.returnValue({
+                homeTeamId: () => { return 109; },
+                awayTeamVenue: () => {
+                    return {
+                        id: 15,
+                        name: 'Chase Field',
+                        season: '2024',
+                        team_id: 109,
+                        name_display_club: 'D-backs',
+                        team_abbrev: 'ARI'
+                    };
+                }
+            });
+            expect((await gamedayUtil.getXParks('77777', 'abc', 30))).toEqual('');
+            expect((await gamedayUtil.getXParks('77777', 'abc', 0))).toEqual('');
+        });
     });
 });

--- a/spec/gameday-util-spec.js
+++ b/spec/gameday-util-spec.js
@@ -97,7 +97,7 @@ describe('gameday-util', () => {
             spyOn(liveFeed, 'init').and.returnValue({
                 homeTeamId: () => { return 109; },
                 awayTeamVenue: () => {
-                    return  {
+                    return {
                         id: 15,
                         name: 'Chase Field',
                         season: '2024',


### PR DESCRIPTION
Implements #17 

For balls that are gone in 4 or less parks, or gone in 26 or more parks, we will include the ballparks. Otherwise, if your team is the away team, we will say whether the parks include your team's home ballpark.

Examples:

![image](https://github.com/user-attachments/assets/cb895907-fc52-45cd-9e4d-14b6bb7e2995)

![image](https://github.com/user-attachments/assets/23c81521-201a-448c-9b27-6cf98eebe8d4)
