### PR TITLE
Provide chosen player to /pitcher, /pitcher_savant, /batter, /batter_savant, and also re-use browser instance.

### DIFF
--- a/commands/batter.js
+++ b/commands/batter.js
@@ -4,7 +4,11 @@ const { SlashCommandBuilder } = require('@discordjs/builders');
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('batter')
-        .setDescription('View stats on who is batting right now, including platoon splits.'),
+        .setDescription('View slash lines and splits for a specified batter, or just who is batting right now.')
+        .addStringOption(option =>
+            option.setName('player')
+                .setDescription('An active player\'s name.')
+                .setRequired(false)),
     async execute (interaction) {
         try {
             await interactionHandlers.batterHandler(interaction);

--- a/commands/batter_savant.js
+++ b/commands/batter_savant.js
@@ -4,7 +4,11 @@ const { SlashCommandBuilder } = require('@discordjs/builders');
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('batter_savant')
-        .setDescription('View the savant metrics for who is at the plate right now.'),
+        .setDescription('View the savant metrics for a specified player, or whoever is up to bat right now.')
+        .addStringOption(option =>
+            option.setName('player')
+                .setDescription('An active player\'s name.')
+                .setRequired(false)),
     async execute (interaction) {
         try {
             await interactionHandlers.batterSavantHandler(interaction);

--- a/commands/pitcher.js
+++ b/commands/pitcher.js
@@ -4,7 +4,11 @@ const { SlashCommandBuilder } = require('@discordjs/builders');
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('pitcher')
-        .setDescription('View stats on who is pitching right now.'),
+        .setDescription('View stats on a specified pitcher, or who is pitching right now.')
+        .addStringOption(option =>
+            option.setName('player')
+                .setDescription('An active player\'s name.')
+                .setRequired(false)),
     async execute (interaction) {
         try {
             await interactionHandlers.pitcherHandler(interaction);

--- a/commands/pitcher_savant.js
+++ b/commands/pitcher_savant.js
@@ -4,7 +4,11 @@ const { SlashCommandBuilder } = require('@discordjs/builders');
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('pitcher_savant')
-        .setDescription('View the savant metrics for who is on the mound right now.'),
+        .setDescription('View the savant metrics for a specified pitcher, or who is on the mound right now.')
+        .addStringOption(option =>
+            option.setName('player')
+                .setDescription('An active player\'s name.')
+                .setRequired(false)),
     async execute (interaction) {
         try {
             await interactionHandlers.pitcherSavantHandler(interaction);

--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@ const { Client, Collection, GatewayIntentBits } = require('discord.js');
 const gameday = require('./modules/gameday');
 const globalCache = require("./modules/global-cache");
 const queries = require("./database/queries");
+const ReusableBrowser = require("./modules/classes/ReusableBrowser");
 const { LOG_LEVEL } = require('./config/globals');
 const LOGGER = require('./modules/logger')(process.env.LOG_LEVEL?.trim() || LOG_LEVEL.INFO);
 
@@ -28,6 +29,7 @@ BOT.once('ready', async () => {
     LOGGER.info('Ready!');
     globalCache.values.subscribedChannels = await queries.getAllSubscribedChannels();
     LOGGER.info('Subscribed channels: ' + JSON.stringify(globalCache.values.subscribedChannels, null, 2));
+    globalCache.values.browser = new ReusableBrowser();
     await gameday.statusPoll(BOT);
 });
 

--- a/modules/MLB-API-util.js
+++ b/modules/MLB-API-util.js
@@ -12,7 +12,7 @@ const endpoints = {
         return 'https://statsapi.mlb.com/api/v1/schedule?hydrate=lineups&sportId=1&gamePk=' + gamePk + '&teamId=' + teamId;
     },
     hitter: (personId) => {
-        return 'https://statsapi.mlb.com/api/v1/people/' + personId + '/stats?stats=season,statSplits,lastXGames&group=hitting&gameType=R&sitCodes=vl,vr,risp&limit=7';
+        return `https://statsapi.mlb.com/api/v1/people?personIds=${personId}&hydrate=stats(type=[season,statSplits,lastXGames],group=hitting,gameType=R,sitCodes=vl,vr,risp,limit=7)`;
     },
     pitcher: (personId, lastXGamesLimit) => {
         return `https://statsapi.mlb.com/api/v1/people?personIds=${personId}&hydrate=stats(type=[season,lastXGames,sabermetrics,seasonAdvanced,expectedStatistics],groups=pitching,limit=${lastXGamesLimit})`;
@@ -93,6 +93,9 @@ const endpoints = {
     },
     team: (teamId) => {
         return 'https://statsapi.mlb.com/api/v1/teams/' + teamId;
+    },
+    players: () => {
+        return 'https://statsapi.mlb.com/api/v1/sports/1/players?fields=people,fullName,lastName,id,currentTeam,primaryPosition,name,code';
     }
 };
 
@@ -229,7 +232,7 @@ module.exports = {
         try {
             return (await fetch(endpoints.savantPage(personId, type),
                 {
-                    signal: AbortSignal.timeout(6000)
+                    signal: AbortSignal.timeout(10000)
                 }
             )).text();
         } catch (e) {
@@ -245,5 +248,8 @@ module.exports = {
     },
     pitcher: async (personId, lastXGamesLimit) => {
         return (await fetch(endpoints.pitcher(personId, lastXGamesLimit))).json();
+    },
+    players: async () => {
+        return (await fetch(endpoints.players())).json();
     }
 };

--- a/modules/MLB-API-util.js
+++ b/modules/MLB-API-util.js
@@ -12,7 +12,8 @@ const endpoints = {
         return 'https://statsapi.mlb.com/api/v1/schedule?hydrate=lineups&sportId=1&gamePk=' + gamePk + '&teamId=' + teamId;
     },
     hitter: (personId) => {
-        return `https://statsapi.mlb.com/api/v1/people?personIds=${personId}&hydrate=stats(type=[season,statSplits,lastXGames],group=hitting,gameType=R,sitCodes=vl,vr,risp,limit=7)`;
+        LOGGER.debug(`https://statsapi.mlb.com/api/v1/people?personIds=${personId}&hydrate=stats(type=[season,statSplits,lastXGames],group=hitting,gameType=R,sitCodes=[vl,vr,risp],limit=7)`);
+        return `https://statsapi.mlb.com/api/v1/people?personIds=${personId}&hydrate=stats(type=[season,statSplits,lastXGames],group=hitting,gameType=R,sitCodes=[vl,vr,risp],limit=7)`;
     },
     pitcher: (personId, lastXGamesLimit) => {
         return `https://statsapi.mlb.com/api/v1/people?personIds=${personId}&hydrate=stats(type=[season,lastXGames,sabermetrics,seasonAdvanced,expectedStatistics],groups=pitching,limit=${lastXGamesLimit})`;

--- a/modules/classes/ReusableBrowser.js
+++ b/modules/classes/ReusableBrowser.js
@@ -1,0 +1,35 @@
+const puppeteer = require('puppeteer');
+const LOGGER = require('../logger')(process.env.LOG_LEVEL?.trim() || globals.LOG_LEVEL.INFO);
+
+class ReusableBrowser {
+    constructor () {
+        LOGGER.trace('Launching ReusableBrowser...');
+        const launchBrowser = async () => {
+            this.browser = false;
+            this.browser = await puppeteer.launch({
+                headless: true,
+                args: [
+                    '--no-sandbox',
+                    '--disable-setuid-sandbox'
+                ]
+            });
+            this.page = await this.browser.newPage();
+            this.browser.on('disconnected', launchBrowser);
+        };
+
+        (async () => {
+            await launchBrowser();
+        })();
+    }
+
+    getCurrentPage = async () => {
+        if (this.page && !this.page.isClosed()) {
+            return this.page;
+        }
+        this.page = await this.browser.newPage();
+        LOGGER.trace('The ReusableBrowser has ' + (await this.browser.pages()).length + ' pages.');
+        return this.page;
+    };
+}
+
+module.exports = ReusableBrowser;

--- a/modules/command-util.js
+++ b/modules/command-util.js
@@ -507,7 +507,7 @@ module.exports = {
     },
 
     getPitcherEmbed: (pitcher, pitcherInfo, isLiveGame, description) => {
-        const feed = liveFeed.init(require('../spec/data/example-live-feed'));
+        const feed = liveFeed.init(globalCache.values.game.currentLiveFeed);
         if (isLiveGame) {
             const abbreviations = {
                 home: feed.homeAbbreviation(),
@@ -548,7 +548,7 @@ module.exports = {
     },
 
     getBatterEmbed: (batter, batterInfo, isLiveGame, description) => {
-        const feed = liveFeed.init(require('../spec/data/example-live-feed'));
+        const feed = liveFeed.init(globalCache.values.game.currentLiveFeed);
         if (isLiveGame) {
             const abbreviations = {
                 home: feed.homeAbbreviation(),
@@ -591,8 +591,8 @@ module.exports = {
         if (playerName) {
             batter = await module.exports.getClosestPlayer(playerName, 'Batter');
         } else {
-            currentLiveFeed = require('../spec/data/example-live-feed');
-            if (currentLiveFeed && currentLiveFeed.gameData.status.abstractGameState !== 'Live') {
+            currentLiveFeed = globalCache.values.game.currentLiveFeed;
+            if (currentLiveFeed && currentLiveFeed.gameData.status.abstractGameState === 'Live') {
                 batter = currentLiveFeed.liveData.plays.currentPlay.matchup.batter;
             }
         }
@@ -605,8 +605,8 @@ module.exports = {
         if (playerName) {
             batter = await module.exports.getClosestPlayer(playerName, 'Pitcher');
         } else {
-            currentLiveFeed = require('../spec/data/example-live-feed');
-            if (currentLiveFeed && currentLiveFeed.gameData.status.abstractGameState !== 'Live') {
+            currentLiveFeed = globalCache.values.game.currentLiveFeed;
+            if (currentLiveFeed && currentLiveFeed.gameData.status.abstractGameState === 'Live') {
                 batter = currentLiveFeed.liveData.plays.currentPlay.matchup.pitcher;
             }
         }

--- a/modules/livefeed.js
+++ b/modules/livefeed.js
@@ -39,6 +39,9 @@ module.exports = {
             },
             linescore: () => {
                 return liveFeed.liveData.linescore;
+            },
+            currentBatterBatSide: () => {
+                return liveFeed.liveData.plays.currentPlay.matchup.batSide.code;
             }
         };
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "discord.js": "^14.15.2",
         "jasmine": "^5.1.0",
         "join-images": "^1.1.5",
+        "js-levenshtein": "^1.1.6",
         "jsdom": "^24.1.0",
         "pg": "^8.12.0",
         "puppeteer": "^22.10.0",
@@ -5597,6 +5598,14 @@
       },
       "peerDependencies": {
         "sharp": "^0.32.0"
+      }
+    },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "discord.js": "^14.15.2",
     "jasmine": "^5.1.0",
     "join-images": "^1.1.5",
+    "js-levenshtein": "^1.1.6",
     "jsdom": "^24.1.0",
     "pg": "^8.12.0",
     "puppeteer": "^22.10.0",


### PR DESCRIPTION
- adds an option to provide a player to the /batter, /batter_savant, /pitcher, and /pitcher_savant commands. If one is not provided, it will check for the current batter/pitcher in a live game as it did before.
- launch a puppeteer instance on startup and re-use it for everything. This is faster and more efficient.


![image](https://github.com/user-attachments/assets/cd9e7ab4-6b52-4c44-8585-78f7a50f8558)
