### PR TITLE
Simplify restricted command check

### DIFF
--- a/config/globals.js
+++ b/config/globals.js
@@ -71,7 +71,6 @@ module.exports = {
     HIGHLIGHTS_PER_MESSAGE: 8,
     SCORING_PLAYS_PER_MESSAGE: 8,
     DATE: null,
-    ADMIN_ROLES: [ "Mod", "Moderator" ],
     TEAM_COLOR_CONTRAST_RATIO: 1.5,
     HOME_RUN_PARKS_MIN: 5,
     HOME_RUN_PARKS_MAX: 25,

--- a/modules/interaction-handlers.js
+++ b/modules/interaction-handlers.js
@@ -1,4 +1,4 @@
-const { AttachmentBuilder, EmbedBuilder } = require('discord.js');
+const { AttachmentBuilder, EmbedBuilder, PermissionsBitField } = require('discord.js');
 const globalCache = require('./global-cache');
 const mlbAPIUtil = require('./MLB-API-util');
 const { joinImages } = require('join-images');
@@ -160,7 +160,7 @@ module.exports = {
 
     subscribeGamedayHandler: async (interaction) => {
         console.info(`SUBSCRIBE GAMEDAY command invoked by guild: ${interaction.guildId}`);
-        if (!interaction.member.roles.cache.some(role => globals.ADMIN_ROLES.includes(role.name))) {
+        if (!interaction.member.permissions.has(PermissionsBitField.Flags.ManageMessages)) {
             await interaction.reply({
                 ephemeral: true,
                 content: 'You do not have permission to subscribe channels to the Gameday feed.'
@@ -205,7 +205,7 @@ module.exports = {
 
     testGamedayReportingHandler: async (interaction) => {
         console.info(`TEST GAMEDAY REPORTING command invoked by guild: ${interaction.guildId}`);
-        if (!interaction.member.roles.cache.some(role => globals.ADMIN_ROLES.includes(role.name))) {
+        if (!interaction.member.permissions.has(PermissionsBitField.Flags.ManageMessages)) {
             await interaction.reply({
                 ephemeral: true,
                 content: 'You do not have permission to use this command.'
@@ -254,7 +254,7 @@ module.exports = {
 
     gamedayPreferenceHandler: async (interaction) => {
         console.info(`GAMEDAY PREFERENCE command invoked by guild: ${interaction.guildId}`);
-        if (!interaction.member.roles.cache.some(role => globals.ADMIN_ROLES.includes(role.name))) {
+        if (!interaction.member.permissions.has(PermissionsBitField.Flags.ManageMessages)) {
             await interaction.reply({
                 ephemeral: true,
                 content: 'You do not have permission to use this command.'
@@ -301,7 +301,7 @@ module.exports = {
 
     unSubscribeGamedayHandler: async (interaction) => {
         console.info(`UNSUBSCRIBE GAMEDAY command invoked by guild: ${interaction.guildId}`);
-        if (!interaction.member.roles.cache.some(role => globals.ADMIN_ROLES.includes(role.name))) {
+        if (!interaction.member.permissions.has(PermissionsBitField.Flags.ManageMessages)) {
             await interaction.reply({
                 ephemeral: true,
                 content: 'You do not have permission to un-subscribe channels to the Gameday feed.'


### PR DESCRIPTION
Instead of requiring that users have been given a role specifically titled "mod" or "moderator", we check the permissions flags for the member and see if they have the "manage messages" permission. Mods and admins should both have this permission.