### PR TITLE
Display different stats for the /starters command based on the game type

### DIFF
--- a/modules/command-util.js
+++ b/modules/command-util.js
@@ -640,11 +640,11 @@ module.exports = {
         });
     },
 
-    buildPitchingStatsMarkdown: (pitchingStats, pitchMix, lastThree, seasonAdvanced, sabermetrics, includeExtra = false) => {
+    buildPitchingStatsMarkdown: (pitchingStats, pitchMix, lastThree, seasonAdvanced, sabermetrics, gameType, includeExtra = false) => {
         let reply = '';
 
         if (lastThree) {
-            reply += '\n**Recent Games:** \n';
+            reply += `\n**Recent Games${resolveGameType(gameType)}:** \n`;
             reply += `G: ${lastThree.gamesPlayed}, `;
             reply += `ERA: ${lastThree.era}, `;
             reply += `Hits: ${lastThree.hits}, `;
@@ -652,7 +652,7 @@ module.exports = {
             reply += `BB: ${lastThree.baseOnBalls}, `;
             reply += `HR: ${lastThree.homeRuns}\n`;
         }
-        reply += '**All Games:** \n';
+        reply += `**All Games${resolveGameType(gameType)}:** \n`;
         if (!pitchingStats) {
             reply += 'G: 0, ';
             reply += 'W-L: -, ';
@@ -1260,5 +1260,16 @@ function getDivisionAbbreviation (division) {
         return 'W';
     } else {
         return 'C';
+    }
+}
+
+function resolveGameType (gameType) {
+    switch (gameType) {
+        case 'R':
+            return '';
+        case 'P':
+            return ' (Postseason)';
+        case 'S':
+            return ' (Spring Training)';
     }
 }

--- a/modules/interaction-handlers.js
+++ b/modules/interaction-handlers.js
@@ -32,8 +32,8 @@ module.exports = {
         }
         const matchup = await mlbAPIUtil.matchup(game.gamePk);
         const probables = matchup.probables;
-        const hydratedHomeProbable = await commandUtil.hydrateProbable(probables.homeProbable);
-        const hydratedAwayProbable = await commandUtil.hydrateProbable(probables.awayProbable);
+        const hydratedHomeProbable = await commandUtil.hydrateProbable(probables.homeProbable, matchup.probables.gameType);
+        const hydratedAwayProbable = await commandUtil.hydrateProbable(probables.awayProbable, matchup.probables.gameType);
         joinImages([hydratedHomeProbable.spot, hydratedAwayProbable.spot],
             { direction: 'horizontal', offset: 10, margin: 0, color: 'transparent' })
             .then(async (img) => {
@@ -50,7 +50,8 @@ module.exports = {
                             hydratedHomeProbable.pitchMix,
                             hydratedHomeProbable.pitchingStats.lastXGames,
                             hydratedHomeProbable.pitchingStats.seasonAdvanced,
-                            hydratedHomeProbable.pitchingStats.sabermetrics
+                            hydratedHomeProbable.pitchingStats.sabermetrics,
+                            matchup.probables.gameType
                         ),
                         inline: true
                     })
@@ -63,7 +64,8 @@ module.exports = {
                             hydratedAwayProbable.pitchMix,
                             hydratedAwayProbable.pitchingStats.lastXGames,
                             hydratedAwayProbable.pitchingStats.seasonAdvanced,
-                            hydratedAwayProbable.pitchingStats.sabermetrics
+                            hydratedAwayProbable.pitchingStats.sabermetrics,
+                            matchup.probables.gameType
                         ),
                         inline: true
                     });
@@ -492,6 +494,7 @@ module.exports = {
                     pitcherInfo.pitchingStats.lastXGames,
                     pitcherInfo.pitchingStats.seasonAdvanced,
                     pitcherInfo.pitchingStats.sabermetrics,
+                    (statType || 'R'),
                     true
                 ),
                 (statType || 'R'),


### PR DESCRIPTION
- for the /starters command, use spring training stats/postseason stats/regular season stats for spring trainig/postseason/regular season games, respectively.