### PR TITLE
More scalable, efficient baseball savant metrics polling

### DIFF
--- a/modules/command-util.js
+++ b/modules/command-util.js
@@ -1099,7 +1099,7 @@ function addAdditionalDataToStats (statCollection, metricSummaries) {
 }
 
 function calculateRoundedPercentileFromNormalDistribution (metric, value, mean, standardDeviation, shouldInvert) {
-    if (standardDeviation === 0) { // This scenario indicates all the values are equal to the mean. This was observed for "Baserunning Run Value" early in the year. This prevents us from diving by 0 in this case.
+    if (standardDeviation === 0) { // This scenario indicates all the values are equal to the mean. This was observed for "Baserunning Run Value" early in the year. This prevents us from dividing by 0 in this case.
         return 50;
     }
     if (typeof value === 'string') {

--- a/modules/gameday.js
+++ b/modules/gameday.js
@@ -291,12 +291,11 @@ async function maybePopulateAdvancedStatcastMetrics (play, messages, gamePk, emb
 function notifySavantDataUnavailable (messages, embed) {
     for (let i = 0; i < messages.length; i ++) {
         embed.data.description = embed.data.description.replaceAll('Pending...', 'Not Available.');
-        if (messages[i].discordMessage) {
+        if (messages[i].discordMessage && !messages[i].discordMessage.doneEditing) {
             messages[i].discordMessage.edit({
                 embeds: [embed]
             }).then((m) => LOGGER.trace('Edited: ' + m.id)).catch((e) => {
                 console.error(e);
-                messages[i].doneEditing = true;
             });
             messages[i].doneEditing = true;
         }

--- a/modules/gameday.js
+++ b/modules/gameday.js
@@ -206,7 +206,6 @@ async function processAndPushPlay (bot, play, gamePk, atBatIndex, includeTitle =
                 } else {
                     LOGGER.debug('Waiting ' + channelSubscription.delay + ' seconds for channel: ' + channelSubscription.channel_id);
                     message.delayed = true;
-                    message.doneEditing = true; // since it has not been sent, don't yet consider it for editing with statcast metrics.
                     sendDelayedMessage(play, gamePk, channelSubscription, returnedChannel, embed, message);
                 }
                 messages.push(message);
@@ -261,7 +260,6 @@ function sendDelayedMessage (play, gamePk, channelSubscription, returnedChannel,
             message.discordMessage = await returnedChannel.send({
                 embeds: [embed]
             });
-            message.doneEditing = false; // now that it has been sent, it may need edited with statcast metrics.
         } catch (e) {
             LOGGER.error(e);
         }
@@ -357,12 +355,11 @@ async function processMatchingPlay (matchingPlay, messages, playId, hitDistance,
                 embed.data.description = embed.data.description.replaceAll('xBA: Pending...', 'xBA: ' + matchingPlay.xba +
                     (matchingPlay.is_barrel === 1 ? ' \uD83D\uDFE2 (Barreled)' : ''));
             }
-            if (messages[i].discordMessage && !messages[i].xbaEdited) { // discordMessage will not be defined for a delayed message that has not sent yet.
+            if (messages[i].discordMessage && messages[i].discordMessage.embeds[0].data.description.includes('xBA: Pending...')) { // discordMessage will not be defined for a delayed message that has not sent yet.
                 messages[i].discordMessage.edit({
                     embeds: [embed]
                 }).then((m) => {
                     LOGGER.trace('xBA Edited: ' + m.id);
-                    messages[i].xbaEdited = true;
                 }).catch((e) => {
                     console.error(e);
                     messages[i].doneEditing = true;
@@ -374,15 +371,13 @@ async function processMatchingPlay (matchingPlay, messages, playId, hitDistance,
                 LOGGER.debug('Editing with Bat Speed: ' + playId);
                 console.timeEnd('Bat Speed: ' + playId);
                 embed.data.description = embed.data.description.replaceAll('Bat Speed: Pending...', 'Bat Speed: ' + matchingPlay.batSpeed + ' mph' +
-                    (matchingPlay.isSword ? ' \u2694\uFE0F (Sword)' : '') +
                     (matchingPlay.batSpeed >= 75.0 ? ' \u26A1' : ''));
             }
-            if (messages[i].discordMessage && !messages[i].batSpeedEdited) {
+            if (messages[i].discordMessage && messages[i].discordMessage.embeds[0].data.description.includes('Bat Speed: Pending...')) {
                 messages[i].discordMessage.edit({
                     embeds: [embed]
                 }).then((m) => {
                     LOGGER.trace('Bat Speed Edited: ' + m.id);
-                    messages[i].batSpeedEdited = true;
                 }).catch((e) => {
                     console.error(e);
                     messages[i].doneEditing = true;
@@ -402,12 +397,11 @@ async function processMatchingPlay (matchingPlay, messages, playId, hitDistance,
                     (await gamedayUtil.getXParks(feed.gamePk(), playId, matchingPlay.contextMetrics.homeRunBallparks));
                 embed.data.description = embed.data.description.replaceAll('HR/Park: Pending...', homeRunBallParksDescription);
             }
-            if (messages[i].discordMessage && !messages[i].homeRunBallparksEdited) {
+            if (messages[i].discordMessage && messages[i].discordMessage.embeds[0].data.description.includes('HR/Park: Pending...')) {
                 messages[i].discordMessage.edit({
                     embeds: [embed]
                 }).then((m) => {
                     LOGGER.trace('HR/Park Edited: ' + m.id);
-                    messages[i].homeRunBallParksEdited = true;
                 }).catch((e) => {
                     console.error(e);
                     messages[i].doneEditing = true;

--- a/modules/gameday.js
+++ b/modules/gameday.js
@@ -291,7 +291,7 @@ async function maybePopulateAdvancedStatcastMetrics (play, messages, gamePk, emb
 function notifySavantDataUnavailable (messages, embed) {
     for (let i = 0; i < messages.length; i ++) {
         embed.data.description = embed.data.description.replaceAll('Pending...', 'Not Available.');
-        if (messages[i].discordMessage && !messages[i].discordMessage.doneEditing) {
+        if (messages[i].discordMessage && !messages[i].doneEditing) {
             messages[i].discordMessage.edit({
                 embeds: [embed]
             }).then((m) => LOGGER.trace('Edited: ' + m.id)).catch((e) => {

--- a/modules/gameday.js
+++ b/modules/gameday.js
@@ -133,7 +133,7 @@ async function reportPlays (bot, gamePk) {
             ), gamePk, atBatIndex - 1);
         /* the below block detects and handles if we missed the result of an at-bat due to the data moving too fast.
          Sometimes it progresses to the next at bat quite quickly. */
-        } else if (lastReportedCompleteAtBatIndex !== null
+        } else if (lastAtBat && lastReportedCompleteAtBatIndex !== null
             && (atBatIndex - lastReportedCompleteAtBatIndex > 1)) {
             LOGGER.debug('Missed at-bat index: ' + atBatIndex - 1);
             await reportAnyMissedEvents(lastAtBat, bot, gamePk, atBatIndex - 1);

--- a/modules/gameday.js
+++ b/modules/gameday.js
@@ -357,7 +357,7 @@ async function processMatchingPlay (matchingPlay, messages, playId, hitDistance,
                 embed.data.description = embed.data.description.replaceAll('xBA: Pending...', 'xBA: ' + matchingPlay.xba +
                     (matchingPlay.is_barrel === 1 ? ' \uD83D\uDFE2 (Barreled)' : ''));
             }
-            if (messages[i].discordMessage && !messages[i].xbaEdited) { // will not be defined for a delayed message that has not sent yet.
+            if (messages[i].discordMessage && !messages[i].xbaEdited) { // discordMessage will not be defined for a delayed message that has not sent yet.
                 messages[i].discordMessage.edit({
                     embeds: [embed]
                 }).then((m) => {

--- a/spec/gameday-spec.js
+++ b/spec/gameday-spec.js
@@ -100,12 +100,14 @@ describe('gameday', () => {
             const messages = [
                 {
                     discordMessage: {
-                        edit: () => { return new Promise(resolve => resolve({ id: 'message-id-1' })); }
+                        edit: () => { return new Promise(resolve => resolve({ id: 'message-id-1' })); },
+                        embeds: [structuredClone(mockEmbed)]
                     }
                 },
                 {
                     discordMessage: {
-                        edit: () => { return new Promise(resolve => resolve({ id: 'message-id-1' })); }
+                        edit: () => { return new Promise(resolve => resolve({ id: 'message-id-1' })); },
+                        embeds: [structuredClone(mockEmbed)]
                     }
                 }
             ];
@@ -137,12 +139,14 @@ describe('gameday', () => {
             const messages = [
                 {
                     discordMessage: {
-                        edit: () => { return new Promise(resolve => resolve({ id: 'message-id-1' })); }
+                        edit: () => { return new Promise(resolve => resolve({ id: 'message-id-1' })); },
+                        embeds: [structuredClone(mockEmbed)]
                     }
                 },
                 {
                     discordMessage: {
-                        edit: () => { return new Promise(resolve => resolve({ id: 'message-id-1' })); }
+                        edit: () => { return new Promise(resolve => resolve({ id: 'message-id-1' })); },
+                        embeds: [structuredClone(mockEmbed)]
                     }
                 }
             ];


### PR DESCRIPTION
Before, we were polling baseball savant individually for any message that has a reporting delay. If you had several channels subscribed with a reporting delay, this resulted in a lot of unnecessary data transfer between us and the baseball savant site. It also led to unnecessary edits of messages.

Now:
- conduct a single poll for each applicable play. When metrics are found, edit the in-memory embed for the play, and also edit the embeds of any messages that have already been sent. For messages that have not yet been sent, do nothing.
- Whenever delayed messages do get sent, they will simply be sent with whatever the state of the in-memory embed is. If all the metrics have been found, then great. If not, as soon as the message is sent, we mark it as needing editing - so the next poll will pick it up as a new message for which to edit the sent embed.

We can sort of see that play out in the logs here - we have 3 channels subscribed. One with no delay, one with a 15 second delay, and one with a 120 second delay. When the xBA is found for the play, we edit two messages with the data, as only the 0 second delay and 15 second delay messages have been sent. 

![image](https://github.com/user-attachments/assets/ab936975-9851-4e3e-ba74-192d68534b53)

By the time we find Bat Speed, the third message has been sent also. So it is edited along with the first two messages. After that is done, all 3 messages have all the data from just a single polling loop.

![image](https://github.com/user-attachments/assets/f9c71629-b551-4e7f-a209-439d2adaf000)

