### PR TITLE
Fix edge case where we looked for emojis before they were initialized

### DIFF
--- a/main.js
+++ b/main.js
@@ -26,13 +26,15 @@ for (const file of commandFiles) {
 
 BOT.once('ready', async () => {
     LOGGER.info('Ready!');
-    BOT.application.emojis.fetch().then(emojis => {
+    let emojis;
+    try {
+        emojis = await BOT.application.emojis.fetch();
         LOGGER.info('Fetched application emojis.');
         globalCache.values.emojis = Array.from(emojis.values());
-    }).catch(e => {
+    } catch (e) {
         console.error(e);
         globalCache.values.emojis = [];
-    });
+    }
     globalCache.values.subscribedChannels = await queries.getAllSubscribedChannels();
     LOGGER.info('Subscribed channels: ' + JSON.stringify(globalCache.values.subscribedChannels, null, 2));
     await gameday.statusPoll(BOT);


### PR DESCRIPTION
There was a possibility, due to how async code is set up, where we would look for the emojis for the teams involved in a currently live game before they were initialized. Changed to an `await` within a try catch, so we're guaranteed to initialize the variable one way or another before doing a poll for live games. 