### PR TITLE
Correctly indicate when savant page request times out

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/modules/MLB-API-util.js
+++ b/modules/MLB-API-util.js
@@ -261,12 +261,15 @@ module.exports = {
         try {
             return (await fetch(endpoints.savantPage(personId, type),
                 {
-                    signal: AbortSignal.timeout(10000)
+                    signal: AbortSignal.timeout(15000)
                 }
             )).text();
         } catch (e) {
             LOGGER.error(e);
-            return {};
+            if (e.name === 'TimeoutError') {
+                return new Error('Timed out trying to retrieve statcast data. Please try your command again.');
+            }
+            return new Error('Could not find statcast data for this player for the chosen season.');
         }
     },
     hitter: async (personId, statType, season) => {

--- a/modules/interaction-handlers.js
+++ b/modules/interaction-handlers.js
@@ -560,6 +560,12 @@ module.exports = {
         const playerResult = await commandUtil.resolvePlayer(interaction, playerName, 'Batter');
         if (!playerResult) return;
         const text = await mlbAPIUtil.savantPage(playerResult.player.id, 'hitting');
+        if (text instanceof Error) {
+            await interaction.followUp({
+                content: text.message
+            });
+            return;
+        }
         const statcastData = commandUtil.getStatcastData(text, interaction.options.getInteger('year'));
         if (statcastData.matchingStatcast && statcastData.matchingMetricYear && statcastData.metricSummaryJSON) {
             const batterInfo = await commandUtil.hydrateHitter(
@@ -593,6 +599,12 @@ module.exports = {
         const playerResult = await commandUtil.resolvePlayer(interaction, playerName, 'Pitcher');
         if (!playerResult) return;
         const text = await mlbAPIUtil.savantPage(playerResult.player.id, 'pitching');
+        if (text instanceof Error) {
+            await interaction.followUp({
+                content: text.message
+            });
+            return;
+        }
         const statcastData = commandUtil.getStatcastData(text, interaction.options.getInteger('year'));
         if (statcastData.matchingStatcast && statcastData.matchingMetricYear && statcastData.metricSummaryJSON) {
             const pitcherInfo = await commandUtil.hydrateProbable(


### PR DESCRIPTION
We were responding with a message that indicated we couldn't find stats for the chosen season for the chosen player, but the stats do exist, we just timed out trying to fetch them. This fix provides a less misleading message in these cases:

First one is the old message, second one is the new.

![image](https://github.com/user-attachments/assets/8039465f-29ce-4354-bbe8-8f898b4095e7)
