### PR TITLE
handle lack of permissions to view channel

### DIFF
--- a/modules/gameday.js
+++ b/modules/gameday.js
@@ -196,7 +196,13 @@ async function processAndPushPlay (bot, play, gamePk, atBatIndex, includeTitle =
         );
         const messages = [];
         for (const channelSubscription of globalCache.values.subscribedChannels) {
-            const returnedChannel = await bot.channels.fetch(channelSubscription.channel_id);
+            let returnedChannel;
+            try {
+                returnedChannel = await bot.channels.fetch(channelSubscription.channel_id);
+            } catch(e) { // an error would be caught here if we, for example, did not have permission to see the requested channel.
+                LOGGER.error(e);
+                continue;
+            }
             if (!play.isScoringPlay && channelSubscription.scoring_plays_only) {
                 LOGGER.debug('Skipping - against the channel\'s preference');
             } else {

--- a/modules/gameday.js
+++ b/modules/gameday.js
@@ -199,7 +199,8 @@ async function processAndPushPlay (bot, play, gamePk, atBatIndex, includeTitle =
             let returnedChannel;
             try {
                 returnedChannel = await bot.channels.fetch(channelSubscription.channel_id);
-            } catch(e) { // an error would be caught here if we, for example, did not have permission to see the requested channel.
+            // an error would be caught here if we, for example, did not have permission to see the requested channel.
+            } catch (e) {
                 LOGGER.error(e);
                 continue;
             }


### PR DESCRIPTION
Channels that the bot doesn't have permissions to view will return HTTP 404, which messes up our reporting of plays and polling for advanced statcast metrics.

Now we simply continue to the next message if this happens. 