### PR TITLE
display current pitcher's pitches-strikes at end of half inning

### DIFF
--- a/modules/current-play-processor.js
+++ b/modules/current-play-processor.js
@@ -53,7 +53,8 @@ module.exports = {
             isInPlay: (lastEvent?.details?.isInPlay || currentPlayJSON.details?.isInPlay),
             playId: (lastEvent?.playId || currentPlayJSON.playId),
             metricsAvailable: (lastEvent?.hitData?.launchSpeed !== undefined || currentPlayJSON.hitData?.launchSpeed !== undefined),
-            hitDistance: (lastEvent?.hitData?.totalDistance || currentPlayJSON.hitData?.totalDistance)
+            hitDistance: (lastEvent?.hitData?.totalDistance || currentPlayJSON.hitData?.totalDistance),
+            currentPitcherId: currentPlayJSON.matchup?.pitcher?.id
         };
     }
 };

--- a/modules/gameday-util.js
+++ b/modules/gameday-util.js
@@ -50,7 +50,7 @@ module.exports = {
         const feed = liveFeed.init(globalCache.values.game.currentLiveFeed);
         const boxscore = feed.boxscore();
         const mergedPlayers = { ...boxscore.teams.away.players, ...boxscore.teams.home.players };
-        const currentPitcher = mergedPlayers[`ID${play.currentPitcherId}`]
+        const currentPitcher = mergedPlayers[`ID${play.currentPitcherId}`];
         return `\n\n**Pitcher**: ${currentPitcher?.person.fullName}, ${currentPitcher?.stats.pitching.numberOfPitches} P - ${currentPitcher?.stats.pitching.strikes} S\n`;
     },
 

--- a/modules/gameday-util.js
+++ b/modules/gameday-util.js
@@ -46,6 +46,14 @@ module.exports = {
         globalCache.values.game.awayTeamEmoji = globalCache.values.emojis.find(e => e.name.includes(feed.awayTeamId()));
     },
 
+    getCurrentPitcherPitchesStrikes: (play) => {
+        const feed = liveFeed.init(globalCache.values.game.currentLiveFeed);
+        const boxscore = feed.boxscore();
+        const mergedPlayers = { ...boxscore.teams.away.players, ...boxscore.teams.home.players };
+        const currentPitcher = mergedPlayers[`ID${play.currentPitcherId}`]
+        return `\n\n**Pitcher**: ${currentPitcher?.person.fullName}, ${currentPitcher?.stats.pitching.numberOfPitches} P - ${currentPitcher?.stats.pitching.strikes} S\n`;
+    },
+
     getDueUp: () => {
         const feed = liveFeed.init(globalCache.values.game.currentLiveFeed);
         const linescore = feed.linescore();
@@ -53,7 +61,7 @@ module.exports = {
         const onDeckIndex = linescore.offense.battingOrder >= 9 ? (linescore.offense.battingOrder + 1) % 9 : linescore.offense.battingOrder + 1;
         const inHoleIndex = linescore.offense.battingOrder >= 8 ? (linescore.offense.battingOrder + 2) % 9 : linescore.offense.battingOrder + 2;
 
-        return '\n\n**Due up**: ' +
+        return '**Due up**: ' +
             upIndex + '. ' + linescore.offense?.batter?.fullName + ', ' +
             onDeckIndex + '. ' + linescore.offense?.onDeck?.fullName + ', ' +
             inHoleIndex + '. ' + linescore.offense?.inHole?.fullName;

--- a/modules/gameday.js
+++ b/modules/gameday.js
@@ -1,3 +1,14 @@
+/**
+ * This component concerns subscribing to MLB.com's websocket feed for a live game and in turn reporting that to subscribed Discord channels.
+ * It does that very consistently well, and it took a lot of work to get to that point. But it is not perfect, and I don't think it ever will be.
+ * Once in a while, you will see a missed event, or a misreported event, or some other weird bug. From what I have observed, that is a consequence of MLB's
+ * data feed, which also occasionally makes mistakes. In fact, I have witnessed them sending rare "correction" events live in the wild. And while
+ * corrections can be handled nicely on a webpage, once my bot has broadcast an event out to Discord channels, I can't really
+ * correct it, at least not easily. I don't want to be in the business of trying to fish for and correct previously sent messages - that
+ * is too much overhead and too much complexity for not enough payoff. So, all this to say, if you come into this component
+ * looking to perfect it, while I'm sure there are improvements to make, just be aware: the API we are consuming is not perfect either.
+ */
+
 const mlbAPIUtil = require('./MLB-API-util');
 const globalCache = require('./global-cache');
 const diffPatch = require('./diff-patch');
@@ -226,7 +237,9 @@ async function processAndPushPlay (bot, play, gamePk, atBatIndex, includeTitle =
 
 function constructPlayEmbed (play, feed, includeTitle, homeTeamColor, awayTeamColor, homeTeamEmoji, awayTeamEmoji) {
     const embed = new EmbedBuilder()
-        .setDescription(play.reply + (play.isOut && play.outs === 3 && !gamedayUtil.didGameEnd(play.homeScore, play.awayScore) ? gamedayUtil.getDueUp() : ''))
+        .setDescription(play.reply + (play.isOut && play.outs === 3 && !gamedayUtil.didGameEnd(play.homeScore, play.awayScore)
+            ? `${gamedayUtil.getCurrentPitcherPitchesStrikes(play)}${gamedayUtil.getDueUp()}`
+            : ''))
         .setColor((feed.halfInning() === 'top'
             ? awayTeamColor
             : homeTeamColor

--- a/modules/livefeed.js
+++ b/modules/livefeed.js
@@ -40,6 +40,9 @@ module.exports = {
             linescore: () => {
                 return liveFeed.liveData.linescore;
             },
+            boxscore: () => {
+                return liveFeed.liveData.boxscore;
+            },
             homeTeamScore: () => {
                 return liveFeed.liveData.plays.currentPlay.result.homeScore;
             },


### PR DESCRIPTION
Mainly for the purpose of tracking how many strikes a starter is throwing and how deep they may make it into the game, we will now display the pitches-strikes for the current pitcher at the end of a half inning.

<img width="550" height="304" alt="image" src="https://github.com/user-attachments/assets/48f66917-8eb8-40d2-b767-fc742882f3ee" />
