### PR TITLE
don't append dash when xParks array is received as empty

### DIFF
--- a/modules/gameday-util.js
+++ b/modules/gameday-util.js
@@ -88,10 +88,11 @@ module.exports = {
             console.error(e);
             return reply;
         }
+        // We only list the parks in extreme cases, e.g. fewer than 4 parks or more than 26.
         if (numberOfParks <= globals.HOME_RUN_PARKS_MIN || numberOfParks >= globals.HOME_RUN_PARKS_MAX) {
-            reply += ' - ';
             const parks = numberOfParks >= globals.HOME_RUN_PARKS_MAX ? xParks.not : xParks.hr;
-            if (parks) {
+            if (parks && parks.length > 0) {
+                reply += ' - ';
                 for (let i = 0; i < parks.length; i ++) {
                     reply += parks[i].name + ' (' + parks[i].team_abbrev + ')';
                     if (i < parks.length - 1) {


### PR DESCRIPTION
Savant xParks endpoint is bugged right now, returning empty arrays of parks. In these cases we are still appending a dash to the message as if we are going to list the parks. Don't append the dash in these cases.

<img width="1385" height="307" alt="image" src="https://github.com/user-attachments/assets/87e12db1-7492-482d-b7f8-6e01c0adafcf" />
