### PR TITLE
prevent DOMException

### DIFF
--- a/modules/command-util.js
+++ b/modules/command-util.js
@@ -678,8 +678,8 @@ module.exports = {
             reply += (() => {
                 let arsenal = '';
                 for (let i = 0; i < pitchMix[0].length; i ++) {
-                    arsenal += pitchMix[0][i] + ' (' + pitchMix[1][i] + '%)' +
-                        ': ' + pitchMix[2][i] + ' mph, ' + pitchMix[3][i] + ' BAA' + '\n';
+                    arsenal += (pitchMix[0][i] || 'N/A') + ' (' + (pitchMix[1][i] || 'N/A') + '%)' +
+                        ': ' + (pitchMix[2][i] || 'N/A') + ' mph, ' + (pitchMix[3][i] || 'N/A') + ' BAA' + '\n';
                 }
                 return arsenal;
             })();
@@ -1008,7 +1008,11 @@ function getPitchCollections (dom) {
         columnMap[th.textContent.trim()] = i + 1;
     });
 
-    const columnData = (header) => `tbody tr td:nth-child(${columnMap[header]})`;
+    const queryColumn = (header) => {
+        return columnMap[header]
+            ? Array.from(document.querySelectorAll(`tbody tr td:nth-child(${columnMap[header]})`))
+            : [];
+    };
 
     const years = [];
     const pitches = [];
@@ -1016,23 +1020,23 @@ function getPitchCollections (dom) {
     const MPHs = [];
     const battingAvgsAgainst = [];
 
-    document.querySelectorAll(columnData('Year')).forEach(el => years.push(el.textContent.trim()));
-    document.querySelectorAll(columnData('Pitch Type')).forEach((el, key) => {
+    queryColumn('Year').forEach(el => years.push(el.textContent.trim()));
+    queryColumn('Pitch Type').forEach((el, key) => {
         if (years[key] === years[0]) {
             pitches.push(el.textContent.trim());
         }
     });
-    document.querySelectorAll(columnData('%')).forEach((el, key) => {
+    queryColumn('%').forEach((el, key) => {
         if (years[key] === years[0]) {
             percentages.push(el.textContent.trim());
         }
     });
-    document.querySelectorAll(columnData('MPH')).forEach((el, key) => {
+    queryColumn('MPH').forEach((el, key) => {
         if (years[key] === years[0]) {
             MPHs.push(el.textContent.trim());
         }
     });
-    document.querySelectorAll(columnData('BA')).forEach((el, key) => {
+    queryColumn('BA').forEach((el, key) => {
         if (years[key] === years[0]) {
             battingAvgsAgainst.push((el.textContent.trim().length > 0 ? el.textContent.trim() : 'N/A'));
         }


### PR DESCRIPTION
 Saw a one-off exception when fetching the pitching arsenal for a pitcher; seems like the table was malformed. We should be more careful with expecting the columns to be there.
 ```
 DOMException [SyntaxError]: unknown pseudo-class selector ':nth-child(undefined)'
2026-04-11T19:50:53.712481+00:00 app[worker.1]: at emit (/app/node_modules/nwsapi/src/nwsapi.js:670:17)
2026-04-11T19:50:53.712482+00:00 app[worker.1]: at compileSelector (/app/node_modules/nwsapi/src/nwsapi.js:1487:17)
2026-04-11T19:50:53.712482+00:00 app[worker.1]: at compile (/app/node_modules/nwsapi/src/nwsapi.js:880:16)
2026-04-11T19:50:53.712482+00:00 app[worker.1]: at collect (/app/node_modules/nwsapi/src/nwsapi.js:1746:22)
2026-04-11T19:50:53.712482+00:00 app[worker.1]: at Object._querySelectorAll [as select] (/app/node_modules/nwsapi/src/nwsapi.js:1701:36)
2026-04-11T19:50:53.712483+00:00 app[worker.1]: at DocumentImpl.querySelectorAll (/app/node_modules/jsdom/lib/jsdom/living/nodes/ParentNode-impl.js:80:26)
2026-04-11T19:50:53.712484+00:00 app[worker.1]: at Document.querySelectorAll (/app/node_modules/jsdom/lib/jsdom/living/generated/Document.js:1051:58)
2026-04-11T19:50:53.712495+00:00 app[worker.1]: at getPitchCollections (/app/modules/command-util.js:1019:14)
2026-04-11T19:50:53.712495+00:00 app[worker.1]: at Object.hydrateProbable (/app/modules/command-util.js:93:58)
2026-04-11T19:50:53.712496+00:00 app[worker.1]: at process.processTicksAndRejections (node:internal/process/task_queues:104: