### PR TITLE
more graceful messaging for problems fetching savant metrics, handle null or NaN for zscore related values

### DIFF
--- a/config/globals.js
+++ b/config/globals.js
@@ -92,6 +92,9 @@ module.exports = {
     SAVANT_POLLING_INTERVAL: 15000,
     SAVANT_POLLING_ATTEMPTS: 10,
     SAVANT_POLLING_BACKOFF_INCREASE: 10000,
+    SAVANT_PAGE_ENDPOINT: (personId, type) => {
+        return `https://baseballsavant.mlb.com/savant-player/${personId}?stats=statcast-r-${type}-mlb`;
+    },
     HOME_RUN_BALLPARKS_MIN_DISTANCE: 300,
     SLOW_POLL_INTERVAL: 300000,
     GAMEDAY_PING_INTERVAL: 10000,

--- a/modules/MLB-API-util.js
+++ b/modules/MLB-API-util.js
@@ -143,7 +143,7 @@ module.exports = {
 
     savantPage: async (personId, type) => {
         try {
-            const endpoint = `https://baseballsavant.mlb.com/savant-player/${personId}?stats=statcast-r-${type}-mlb`;
+            const endpoint = globals.SAVANT_PAGE_ENDPOINT(personId, type);
             LOGGER.debug(endpoint);
             return await (await fetch(endpoint, { signal: AbortSignal.timeout(15000) })).text();
         } catch (e) {

--- a/modules/command-util.js
+++ b/modules/command-util.js
@@ -1115,6 +1115,9 @@ function addAdditionalDataToStats (statCollection, metricSummaries) {
 }
 
 function calculateRoundedPercentileFromNormalDistribution (metric, value, mean, standardDeviation, shouldInvert) {
+    if (mean == null || standardDeviation == null || isNaN(value) || isNaN(mean) || isNaN(standardDeviation)) {
+        return 0;
+    }
     if (standardDeviation === 0) { // This scenario indicates all the values are equal to the mean. This was observed for "Baserunning Run Value" early in the year. This prevents us from dividing by 0 in this case.
         return 50;
     }

--- a/modules/interaction-handlers.js
+++ b/modules/interaction-handlers.js
@@ -642,7 +642,7 @@ module.exports = {
             }
         } else {
             await interaction.editReply({
-                content: `There is no statcast ${savantType === 'pitching' ? savantType : 'hitting/fielding'} data for this player for the chosen season.`
+                content: `I could not retrieve statcast ${savantType === 'pitching' ? savantType : 'hitting/fielding'} data for this player for the chosen season. This could mean that they did not play that year, or it could indicate a temporary issue with Baseball Savant. In the meantime, here is a link to the player's page: ${globals.SAVANT_PAGE_ENDPOINT(playerResult.player.id, savantType)}`
             });
         }
     },

--- a/spec/interaction-handlers-spec.js
+++ b/spec/interaction-handlers-spec.js
@@ -216,7 +216,7 @@ describe('interaction-handlers', () => {
             commandUtil.getStatcastData.and.returnValue({ matchingStatcast: null, matchingMetricYear: null, metricSummaryJSON: null });
             interaction = makeInteraction('Shane Bieber');
             await interactionHandlers.playerSavantHandler(interaction);
-            expect(interaction.editReply).toHaveBeenCalledWith({ content: jasmine.stringContaining('no statcast') });
+            expect(interaction.editReply).toHaveBeenCalledWith({ content: jasmine.stringContaining('could not retrieve') });
             expect(interaction.followUp).not.toHaveBeenCalled();
         });
 


### PR DESCRIPTION
caught the following, not sure of the exact cause. But in these cases, just return percentile 0:

```
1]: TypeError: zscore is not a valid number
2026-04-12T01:33:09.705063+00:00 app[worker.1]: at module.exports (/app/node_modules/ztable/index.js:45:15)
2026-04-12T01:33:09.705063+00:00 app[worker.1]: at calculateRoundedPercentileFromNormalDistribution (/app/modules/command-util.js:1121:79)
2026-04-12T01:33:09.705064+00:00 app[worker.1]: at addAdditionalDataToStats (/app/modules/command-util.js:1095:44)
2026-04-12T01:33:09.705064+00:00 app[worker.1]: at Object.buildBatterSavantTable (/app/modules/command-util.js:454:59)
2026-04-12T01:33:09.705064+00:00 app[worker.1]: at Object.playerSavantHandler (/app/modules/interaction-handlers.js:631:76)
2026-04-12T01:33:09.705064+00:00 app[worker.1]: at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
2026-04-12T01:33:09.705065+00:00 app[worker.1]: at async Object.execute (/app/commands/player_savant.js:23:13)
2026-04-12T01:33:09.705065+00:00 app[worker.1]: at async Client.<anonymous> (/app/main.js:68:9)