### PR TITLE
limit missed at bat logic to a maximum of one missed at bat

### DIFF
--- a/config/globals.js
+++ b/config/globals.js
@@ -358,6 +358,7 @@ module.exports = {
         IN_PROGRESS: "I",
         WARMUP: "PW"
     },
+    MISSED_AT_BAT_INDICATOR: 2,
     /*
      More general codes that capture all statuses in a particular category.
      See: https://github.com/MajorLeagueBaseball/google-cloud-mlb-hackathon/blob/main/datasets/mlb-statsapi-docs/MLB-StatsAPI%20-%20Lookup%20Values.pdf

--- a/modules/gameday.js
+++ b/modules/gameday.js
@@ -145,7 +145,7 @@ async function reportPlays (bot, gamePk) {
             ), gamePk, atBatIndex - 1);
             /* the below block detects and handles if we missed the result of an at-bat due to the data moving too fast.
              Sometimes it progresses to the next at bat quite quickly. */
-        } else if (lastAtBat && (atBatIndex - lastReportedCompleteAtBatIndex > 1)) {
+        } else if (lastAtBat && (atBatIndex - lastReportedCompleteAtBatIndex === globals.MISSED_AT_BAT_INDICATOR)) {
             LOGGER.debug(`Missed at-bat index: ${atBatIndex - 1}`);
             await module.exports.reportAnyMissedEvents(lastAtBat, bot, gamePk, atBatIndex - 1);
             await module.exports.processAndPushPlay(bot, currentPlayProcessor.process(


### PR DESCRIPTION
We handle missing an at bat result by detecting if the current at bat index minus the last reported index is > 1. However, this has the side effect of always reporting multiple at bats when the bot starts up or is restarted in the middle of a game. Since we shouldn't ever miss more than one at bat consecutively, we just changed the check to "is the at bat index difference equal to 2?"