### PR TITLE
further refactor savant polling; several small bugfixes/tweaks

### DIFF
--- a/config/globals.js
+++ b/config/globals.js
@@ -89,9 +89,13 @@ module.exports = {
         'walk',
         'hit_by_pitch'
     ],
-    SAVANT_POLLING_INTERVAL: 15000,
-    SAVANT_POLLING_ATTEMPTS: 10,
-    SAVANT_POLLING_BACKOFF_INCREASE: 10000,
+    SAC_BUNT_EVENT_TYPES: ['sac_bunt', 'sac_bunt_double_play'],
+    SAVANT_POLLING_INTERVAL: 20000,
+    SAVANT_POLLING_ATTEMPTS: 20,
+    SAVANT_XPARKS_POLLING_ATTEMPTS: 10,
+    SAVANT_XPARKS_POLLING_INTERVAL: 15000,
+    SAVANT_XPARKS_POLLING_BACKOFF_INCREASE: 10000,
+    XPARKS_PENDING_PLACEHOLDER_SUFFIX: ' [Park details pending...]',
     SAVANT_PAGE_ENDPOINT: (personId, type) => {
         return `https://baseballsavant.mlb.com/savant-player/${personId}?stats=statcast-r-${type}-mlb`;
     },

--- a/modules/current-play-processor.js
+++ b/modules/current-play-processor.js
@@ -62,6 +62,8 @@ module.exports = {
             playId: (lastEvent?.playId || currentPlayJSON.playId),
             metricsAvailable: (lastEvent?.hitData?.launchSpeed !== undefined || currentPlayJSON.hitData?.launchSpeed !== undefined),
             hitDistance: (lastEvent?.hitData?.totalDistance || currentPlayJSON.hitData?.totalDistance),
+            hasReview: currentPlayJSON.about?.hasReview ?? false,
+            reviewInProgress: currentPlayJSON.reviewDetails?.inProgress ?? false,
             currentPitcherId: currentPlayJSON.matchup?.pitcher?.id
         };
     }

--- a/modules/current-play-processor.js
+++ b/modules/current-play-processor.js
@@ -36,10 +36,10 @@ module.exports = {
                 if (currentPlayJSON.playEvents) {
                     lastEvent = currentPlayJSON.playEvents[currentPlayJSON.playEvents.length - 1];
                     if (lastEvent?.details?.isInPlay) {
-                        reply = addMetrics(lastEvent, reply);
+                        reply = addMetrics(lastEvent, reply, currentPlayJSON.result?.eventType || currentPlayJSON.details?.eventType);
                     }
                 } else if (currentPlayJSON.details?.isInPlay) {
-                    reply = addMetrics(currentPlayJSON, reply);
+                    reply = addMetrics(currentPlayJSON, reply, currentPlayJSON.details?.eventType);
                 }
             }
         }
@@ -86,7 +86,8 @@ function addScore (reply, currentPlayJSON, feed, homeTeamEmoji, awayTeamEmoji) {
     return reply;
 }
 
-function addMetrics (lastEvent, reply) {
+function addMetrics (lastEvent, reply, eventType) {
+    const isSacBunt = globals.SAC_BUNT_EVENT_TYPES.includes(eventType);
     if (lastEvent.hitData.launchSpeed) { // this data can be randomly unavailable
         reply += '\n\n';
         reply += 'Exit Velo: ' + lastEvent.hitData.launchSpeed + ' mph' +
@@ -94,7 +95,9 @@ function addMetrics (lastEvent, reply) {
         reply += 'Launch Angle: ' + lastEvent.hitData.launchAngle + '° \n';
         reply += 'Distance: ' + lastEvent.hitData.totalDistance + ' ft.\n';
         reply += 'xBA: Pending...\n';
-        reply += 'Bat Speed: Pending...';
+        if (!isSacBunt) { // Obviously, sacrifice bunts aren't really a swing. No sense in trying to get the bat speed.
+            reply += 'Bat Speed: Pending...';
+        }
         reply += lastEvent.hitData.totalDistance && lastEvent.hitData.totalDistance >= globals.HOME_RUN_BALLPARKS_MIN_DISTANCE ? '\nHR/Park: Pending...' : '';
     } else {
         reply += '\n\n**Statcast Metrics:**\n';

--- a/modules/gameday-util.js
+++ b/modules/gameday-util.js
@@ -85,7 +85,7 @@ module.exports = {
         let xParks;
         try {
             xParks = await mlbAPIUtil.xParks(gamePk, playId);
-            LOGGER.debug(JSON.stringify(xParks, null, 2));
+            LOGGER.trace(JSON.stringify(xParks, null, 2));
         } catch (e) {
             console.error(e);
             return reply;
@@ -108,10 +108,13 @@ module.exports = {
             }
             return reply;
         } else if (!isHome) {
-            if (xParks.hr.find(park => park.id === feed.awayTeamVenue().id)) {
-                reply += ', including ' + feed.awayTeamVenue().name;
-            } else if (xParks.not.find(park => park.id === feed.awayTeamVenue().id)) {
-                reply += ', but not ' + feed.awayTeamVenue().name;
+            const awayVenueId = feed.awayTeamVenue().id;
+            const hrPark = xParks.hr.find(park => park.id === awayVenueId);
+            const notPark = xParks.not.find(park => park.id === awayVenueId);
+            if (hrPark) {
+                reply += ', including ' + hrPark.name;
+            } else if (notPark) {
+                reply += ', but not ' + notPark.name;
             }
             return reply;
         }

--- a/modules/gameday.js
+++ b/modules/gameday.js
@@ -24,8 +24,20 @@ const savantQueue = new Map();
 let savantLoopRunning = false;
 
 module.exports = {
-    statusPoll, subscribe, processAndPushPlay, pollForSavantData, runSavantPollingLoop, pollForXParksAndEdit, processMatchingPlay, sendMessage, sendDelayedMessage, constructPlayEmbed, reportPlays, reportAnyMissedEvents,
-    savantQueue, get savantLoopRunning () { return savantLoopRunning; }
+    statusPoll,
+    subscribe,
+    processAndPushPlay,
+    pollForSavantData,
+    runSavantPollingLoop,
+    pollForXParksAndEdit,
+    processMatchingPlay,
+    sendMessage,
+    sendDelayedMessage,
+    constructPlayEmbed,
+    reportPlays,
+    reportAnyMissedEvents,
+    savantQueue,
+    get savantLoopRunning () { return savantLoopRunning; }
 };
 
 async function statusPoll (bot) {
@@ -399,7 +411,7 @@ async function runSavantPollingLoop () {
                     savantQueue.delete(playId);
                     continue;
                 }
-                entry.attempts++;
+                entry.attempts ++;
                 if (entry.attempts >= globals.SAVANT_POLLING_ATTEMPTS) {
                     LOGGER.debug('Savant: max attempts reached for: ' + playId + '. Removing from queue.');
                     notifySavantDataUnavailable(messages, embed);

--- a/modules/gameday.js
+++ b/modules/gameday.js
@@ -280,7 +280,7 @@ async function processAndPushPlay (bot, play, gamePk, atBatIndex, includeTitle =
 
 function constructPlayEmbed (play, feed, includeTitle, homeTeamColor, awayTeamColor, homeTeamEmoji, awayTeamEmoji) {
     const embed = new EmbedBuilder()
-        .setDescription(play.reply + (play.isOut && play.outs === 3 && !gamedayUtil.didGameEnd(play.homeScore, play.awayScore)
+        .setDescription(play.reply + (play.isOut && play.outs === 3 && !(play.hasReview && play.reviewInProgress) && !gamedayUtil.didGameEnd(play.homeScore, play.awayScore)
             ? `${gamedayUtil.getPitchesStrikesForPitchersInHalfInning(play)}${gamedayUtil.getDueUp()}`
             : ''))
         .setColor((feed.halfInning() === 'top'
@@ -370,6 +370,16 @@ function editMessages (messages, embed, logLabel = 'Edited') {
     }
 }
 
+function editMessagesWithXParks (messages, embed, logLabel) {
+    for (const message of messages) {
+        if (message.discordMessage) {
+            message.discordMessage.edit({ embeds: [embed] })
+                .then((m) => LOGGER.trace(logLabel + ': ' + m.id))
+                .catch((e) => console.error(e));
+        }
+    }
+}
+
 /* Enqueues a play for savant data polling. A single shared polling loop handles all queued plays. If the loop is already
     running, the play is simply added to the queue. If not, the loop is started first. */
 async function pollForSavantData (gamePk, playId, messages, hitDistance, embed) {
@@ -452,7 +462,7 @@ async function pollForXParksAndEdit (gamePk, playId, numberOfParks, baseHRParkDe
             const pendingPlaceholder = baseHRParkDescription + globals.XPARKS_PENDING_PLACEHOLDER_SUFFIX;
             if (embed.data.description.includes(pendingPlaceholder)) {
                 embed.data.description = embed.data.description.replace(pendingPlaceholder, baseHRParkDescription);
-                editMessages(messages, embed, 'XParks Timeout Edit');
+                editMessagesWithXParks(messages, embed, 'XParks Timeout Edit');
             }
             return;
         }
@@ -463,7 +473,7 @@ async function pollForXParksAndEdit (gamePk, playId, numberOfParks, baseHRParkDe
             const pendingPlaceholder = baseHRParkDescription + globals.XPARKS_PENDING_PLACEHOLDER_SUFFIX;
             if (embed.data.description.includes(pendingPlaceholder)) {
                 embed.data.description = embed.data.description.replace(pendingPlaceholder, baseHRParkDescription + xParksText);
-                editMessages(messages, embed, 'XParks Edited');
+                editMessagesWithXParks(messages, embed, 'XParks Edited');
             }
             return;
         }

--- a/modules/gameday.js
+++ b/modules/gameday.js
@@ -19,8 +19,13 @@ const LOGGER = require('./logger')(process.env.LOG_LEVEL?.trim() || globals.LOG_
 const liveFeed = require('./livefeed');
 const gamedayUtil = require('./gameday-util');
 
+// Shared queue for savant polling: playId -> { gamePk, messages, hitDistance, embed, activeTimers, attempts }
+const savantQueue = new Map();
+let savantLoopRunning = false;
+
 module.exports = {
-    statusPoll, subscribe, processAndPushPlay, pollForSavantData, pollForXParksAndEdit, processMatchingPlay, sendMessage, sendDelayedMessage, constructPlayEmbed, reportPlays, reportAnyMissedEvents
+    statusPoll, subscribe, processAndPushPlay, pollForSavantData, runSavantPollingLoop, pollForXParksAndEdit, processMatchingPlay, sendMessage, sendDelayedMessage, constructPlayEmbed, reportPlays, reportAnyMissedEvents,
+    savantQueue, get savantLoopRunning () { return savantLoopRunning; }
 };
 
 async function statusPoll (bot) {
@@ -353,16 +358,9 @@ function editMessages (messages, embed, logLabel = 'Edited') {
     }
 }
 
-/* We will continue polling for a given play until either:
-    a) all sent messages have been edited with all our selected, applicable metrics. At that point, we may still have
-       delayed messages that have not been sent yet. That is fine - when they are sent, they will just post the current
-       state of the embed, which will include all the metrics we edited already-sent messages with.
-    b) the polling limit is reached, at which point any missing data will be marked as unavailable. Bat speed in particular
-       can take a long time to be populated, and in some cases seems to never populate.
-*/
+/* Enqueues a play for savant data polling. A single shared polling loop handles all queued plays. If the loop is already
+    running, the play is simply added to the queue. If not, the loop is started first. */
 async function pollForSavantData (gamePk, playId, messages, hitDistance, embed) {
-    let attempts = 1;
-    let currentInterval = globals.SAVANT_POLLING_INTERVAL;
     const activeTimers = new Set();
     const startTimer = (label) => { console.time(label); activeTimers.add(label); };
     startTimer('xBA: ' + playId);
@@ -370,27 +368,60 @@ async function pollForSavantData (gamePk, playId, messages, hitDistance, embed) 
     if (hitDistance >= globals.HOME_RUN_BALLPARKS_MIN_DISTANCE) {
         startTimer('HR/Park: ' + playId);
     }
+    const entry = { gamePk, messages, hitDistance, embed, activeTimers, attempts: 0 };
+    if (savantLoopRunning) {
+        LOGGER.debug('Savant: loop already running, enqueueing play: ' + playId);
+        savantQueue.set(playId, entry);
+    } else {
+        savantLoopRunning = true;
+        savantQueue.set(playId, entry);
+        await runSavantPollingLoop();
+    }
+}
+
+/* Single shared polling loop for all queued savant plays. Fetches the savant game feed once per iteration
+   and processes all queued plays against it. Stops when the queue is empty. */
+async function runSavantPollingLoop () {
     const pollingFunction = async () => {
-        if (messages.every(m => m.doneEditing)) {
-            LOGGER.debug(`Savant: all sent messages done for: ${playId}.`);
+        if (savantQueue.size === 0) {
+            LOGGER.debug('Savant: queue empty, stopping loop.');
+            savantLoopRunning = false;
             return;
         }
-        if (attempts < globals.SAVANT_POLLING_ATTEMPTS) {
-            LOGGER.trace('Savant: polling for ' + playId + '...');
+        const gamePk = savantQueue.values().next().value.gamePk;
+        LOGGER.trace('Savant: polling game feed for gamePk ' + gamePk + ' (' + savantQueue.size + ' play(s) queued)...');
+        try {
             const gameFeed = await mlbAPIUtil.savantGameFeed(gamePk);
-            const matchingPlay = gameFeed?.team_away?.find(play => play?.play_id === playId)
-                || gameFeed?.team_home?.find(play => play?.play_id === playId);
-            if (matchingPlay && (matchingPlay.xba
-                || matchingPlay.contextMetrics?.homeRunBallparks !== undefined
-                || matchingPlay.batSpeed !== undefined)) {
-                await module.exports.processMatchingPlay(matchingPlay, messages, playId, hitDistance, embed, activeTimers);
+            for (const [playId, entry] of savantQueue) {
+                const { messages, hitDistance, embed, activeTimers } = entry;
+                if (!entry.embed.data.description.includes('Pending...')) {
+                    LOGGER.debug('Savant: embed has no pending metrics for: ' + playId + '. Removing from queue.');
+                    savantQueue.delete(playId);
+                    continue;
+                }
+                entry.attempts++;
+                if (entry.attempts >= globals.SAVANT_POLLING_ATTEMPTS) {
+                    LOGGER.debug('Savant: max attempts reached for: ' + playId + '. Removing from queue.');
+                    notifySavantDataUnavailable(messages, embed);
+                    savantQueue.delete(playId);
+                    continue;
+                }
+                const matchingPlay = gameFeed?.team_away?.find(play => play?.play_id === playId)
+                    || gameFeed?.team_home?.find(play => play?.play_id === playId);
+                if (matchingPlay && (matchingPlay.xba
+                    || matchingPlay.contextMetrics?.homeRunBallparks !== undefined
+                    || matchingPlay.batSpeed !== undefined)) {
+                    await module.exports.processMatchingPlay(matchingPlay, messages, playId, hitDistance, embed, activeTimers);
+                }
             }
-            attempts ++;
-            currentInterval = currentInterval + globals.SAVANT_POLLING_BACKOFF_INCREASE;
-            setTimeout(async () => { await pollingFunction(); }, currentInterval);
+        } catch (e) {
+            LOGGER.error('Savant polling loop error: ' + e);
+        }
+        if (savantQueue.size === 0) {
+            LOGGER.debug('Savant: queue empty after processing, stopping loop.');
+            savantLoopRunning = false;
         } else {
-            LOGGER.debug('max savant polling attempts reached for: ' + playId);
-            notifySavantDataUnavailable(messages, embed);
+            setTimeout(async () => { await pollingFunction(); }, globals.SAVANT_POLLING_INTERVAL);
         }
     };
     await pollingFunction();
@@ -402,25 +433,30 @@ async function pollForSavantData (gamePk, playId, messages, hitDistance, embed) 
 */
 async function pollForXParksAndEdit (gamePk, playId, numberOfParks, baseHRParkDescription, messages, embed) {
     let attempts = 1;
-    let currentInterval = globals.SAVANT_POLLING_INTERVAL;
+    let currentInterval = globals.SAVANT_XPARKS_POLLING_INTERVAL;
     const pollingFunction = async () => {
-        if (attempts >= globals.SAVANT_POLLING_ATTEMPTS) {
+        if (attempts >= globals.SAVANT_XPARKS_POLLING_ATTEMPTS) {
             LOGGER.debug('XParks: max polling attempts reached for: ' + playId);
+            const pendingPlaceholder = baseHRParkDescription + globals.XPARKS_PENDING_PLACEHOLDER_SUFFIX;
+            if (embed.data.description.includes(pendingPlaceholder)) {
+                embed.data.description = embed.data.description.replace(pendingPlaceholder, baseHRParkDescription);
+                editMessages(messages, embed, 'XParks Timeout Edit');
+            }
             return;
         }
         LOGGER.trace('XParks: polling for ' + playId + '...');
         const xParksText = await gamedayUtil.getXParks(gamePk, playId, numberOfParks);
         if (xParksText !== null) {
             // Data is now available (even if xParksText is ''), replace the pending placeholder.
-            const fullDescription = baseHRParkDescription + xParksText;
-            if (!embed.data.description.includes(fullDescription)) {
-                embed.data.description = embed.data.description.replace(baseHRParkDescription + ' (Park details pending...)', fullDescription);
+            const pendingPlaceholder = baseHRParkDescription + globals.XPARKS_PENDING_PLACEHOLDER_SUFFIX;
+            if (embed.data.description.includes(pendingPlaceholder)) {
+                embed.data.description = embed.data.description.replace(pendingPlaceholder, baseHRParkDescription + xParksText);
                 editMessages(messages, embed, 'XParks Edited');
             }
             return;
         }
         attempts ++;
-        currentInterval = currentInterval + globals.SAVANT_POLLING_BACKOFF_INCREASE;
+        currentInterval = currentInterval + globals.SAVANT_XPARKS_POLLING_BACKOFF_INCREASE;
         setTimeout(async () => { await pollingFunction(); }, currentInterval);
     };
     await pollingFunction();
@@ -458,7 +494,7 @@ async function processMatchingPlay (matchingPlay, messages, playId, hitDistance,
         const baseHRParkDescription = 'HR/Park: ' + numberOfParks + '/30' +
             (numberOfParks === 30 ? '\u203C\uFE0F' : '');
         const xParksText = await gamedayUtil.getXParks(feed.gamePk(), playId, numberOfParks);
-        embed.data.description = embed.data.description.replaceAll('HR/Park: Pending...', baseHRParkDescription + (xParksText ?? ' (Park details pending...)'));
+        embed.data.description = embed.data.description.replaceAll('HR/Park: Pending...', baseHRParkDescription + (xParksText ?? globals.XPARKS_PENDING_PLACEHOLDER_SUFFIX));
         if (xParksText === null) {
             LOGGER.debug('XParks data not ready yet for: ' + playId + '. Polling...');
             pendingXParksArgs = [feed.gamePk(), playId, numberOfParks, baseHRParkDescription];
@@ -476,7 +512,8 @@ async function processMatchingPlay (matchingPlay, messages, playId, hitDistance,
         const needsEdit = sentDescription.includes('xBA: Pending...')
             || sentDescription.includes('Bat Speed: Pending...')
             || sentDescription.includes('HR/Park: Pending...');
-        if (needsEdit) {
+        const descriptionChanged = message.discordMessage.embeds[0].data.description !== embed.data.description;
+        if (needsEdit && descriptionChanged) {
             message.discordMessage.edit({ embeds: [embed] })
                 .then((m) => LOGGER.trace('Edited: ' + m.id))
                 .catch((e) => {

--- a/spec/gameday-spec.js
+++ b/spec/gameday-spec.js
@@ -48,39 +48,50 @@ describe('gameday', () => {
         });
     });
 
-    describe('#pollForSavantData', () => {
-        it('should stop processing if a matching play is found and every message has been edited', async () => {
+    describe('#runSavantPollingLoop', () => {
+        beforeEach(() => {
+            gameday.savantQueue.clear();
+        });
+
+        it('should call processMatchingPlay and stop the loop when a matching play is found and all messages are done', async () => {
             spyOn(mlbAPIUtil, 'savantGameFeed').and.returnValue(new Promise(
                 resolve => resolve(mockResponses.savantGameFeed)
             ));
+            const messages = [{ doneEditing: false }, { doneEditing: false }];
             spyOn(gameday, 'processMatchingPlay').and.callFake((
-                matchingPlay, messages, playId, hitDistance, embed
+                matchingPlay, msgs
             ) => {
-                messages.forEach(m => m.doneEditing = true);
+                msgs.forEach(m => m.doneEditing = true);
             });
+            gameday.savantQueue.set('abc', { gamePk: 1, messages, hitDistance: 350, embed: null, activeTimers: new Set(), attempts: 0 });
             jasmine.clock().install();
-            await gameday.pollForSavantData(1, 'abc', [{}, {}], 350, null);
-            jasmine.clock().tick(globals.SAVANT_POLLING_INTERVAL);
+            await gameday.runSavantPollingLoop();
             expect(mlbAPIUtil.savantGameFeed).toHaveBeenCalledTimes(1);
             expect(gameday.processMatchingPlay).toHaveBeenCalled();
+            expect(gameday.savantLoopRunning).toBe(false);
             jasmine.clock().uninstall();
         });
 
-        it('should poll again if a matching play is not found', async () => {
+        it('should poll again if a matching play is not yet in the feed', async () => {
             spyOn(mlbAPIUtil, 'savantGameFeed').and.returnValue(new Promise(
                 resolve => resolve(mockResponses.savantGameFeed)
             ));
-            spyOn(gameday, 'processMatchingPlay').and.callFake((
-                matchingPlay, messages, playId, hitDistance, embed
-            ) => {
-                messages.forEach(m => m.doneEditing = true);
-            });
+            spyOn(gameday, 'processMatchingPlay').and.stub();
+            const messages = [{ doneEditing: false }];
+            gameday.savantQueue.set('xyz', { gamePk: 1, messages, hitDistance: 350, embed: null, activeTimers: new Set(), attempts: 0 });
             jasmine.clock().install();
-            await gameday.pollForSavantData(1, 'xyz', [{}, {}], 350);
-            jasmine.clock().tick(globals.SAVANT_POLLING_INTERVAL + globals.SAVANT_POLLING_BACKOFF_INCREASE);
+            await gameday.runSavantPollingLoop();
+            jasmine.clock().tick(globals.SAVANT_POLLING_INTERVAL);
             expect(mlbAPIUtil.savantGameFeed).toHaveBeenCalledTimes(2);
             expect(gameday.processMatchingPlay).not.toHaveBeenCalled();
             jasmine.clock().uninstall();
+        });
+
+        it('should stop immediately if the queue is empty', async () => {
+            spyOn(mlbAPIUtil, 'savantGameFeed').and.stub();
+            await gameday.runSavantPollingLoop();
+            expect(mlbAPIUtil.savantGameFeed).not.toHaveBeenCalled();
+            expect(gameday.savantLoopRunning).toBe(false);
         });
     });
 

--- a/spec/gameday-spec.js
+++ b/spec/gameday-spec.js
@@ -58,12 +58,13 @@ describe('gameday', () => {
                 resolve => resolve(mockResponses.savantGameFeed)
             ));
             const messages = [{ doneEditing: false }, { doneEditing: false }];
+            const embed = { data: { description: 'xBA: Pending...' } };
             spyOn(gameday, 'processMatchingPlay').and.callFake((
-                matchingPlay, msgs
+                matchingPlay, msgs, playId, hitDistance, emb
             ) => {
-                msgs.forEach(m => m.doneEditing = true);
+                emb.data.description = 'xBA: .450';
             });
-            gameday.savantQueue.set('abc', { gamePk: 1, messages, hitDistance: 350, embed: null, activeTimers: new Set(), attempts: 0 });
+            gameday.savantQueue.set('abc', { gamePk: 1, messages, hitDistance: 350, embed, activeTimers: new Set(), attempts: 0 });
             jasmine.clock().install();
             await gameday.runSavantPollingLoop();
             expect(mlbAPIUtil.savantGameFeed).toHaveBeenCalledTimes(1);
@@ -78,7 +79,8 @@ describe('gameday', () => {
             ));
             spyOn(gameday, 'processMatchingPlay').and.stub();
             const messages = [{ doneEditing: false }];
-            gameday.savantQueue.set('xyz', { gamePk: 1, messages, hitDistance: 350, embed: null, activeTimers: new Set(), attempts: 0 });
+            const embed = { data: { description: 'xBA: Pending...' } };
+            gameday.savantQueue.set('xyz', { gamePk: 1, messages, hitDistance: 350, embed, activeTimers: new Set(), attempts: 0 });
             jasmine.clock().install();
             await gameday.runSavantPollingLoop();
             jasmine.clock().tick(globals.SAVANT_POLLING_INTERVAL);


### PR DESCRIPTION
- further rework our polling for savant metrics to make it so we only ever have a maximum of one polling loop running at a given time. This should reduce our network footprint significantly a lot of the time. Plays are added to a queue, and all plays in the queue are addressed by each attempt in the polling loop. If the queue is empty, the polling is stopped.

<img width="1641" height="362" alt="image" src="https://github.com/user-attachments/assets/816e8005-e017-4e07-ac29-e6fbe4973267" />

- don't attempt to get the bat speed for sacrifice bunts. It's not a swing and this data ends up being unavailable.
- fix issue preventing xParks from being edited in, because we had marked all messages as "done editing" when they have everything but the park details
- don't display pitches-strikes data and who is due up next inning if we are simply reporting an in progress challenge.