### PR TITLE
remove low max retry to keep trying to reconnect the socket

### DIFF
--- a/modules/MLB-API-util.js
+++ b/modules/MLB-API-util.js
@@ -64,7 +64,7 @@ module.exports = {
         const { WebSocket } = require('ws');
         const wsUrl = `wss://ws.statsapi.mlb.com/api/v1/game/push/subscribe/gameday/${gamePk}`;
         LOGGER.debug(wsUrl);
-        const socket = new ReconnectingWebSocket(wsUrl, [], { WebSocket, maxRetries: 3 });
+        const socket = new ReconnectingWebSocket(wsUrl, [], { WebSocket });
         let heartbeatInterval;
         /*
             This is the same ping that Gameday web clients send to the socket server. If you observe the network traffic

--- a/modules/gameday.js
+++ b/modules/gameday.js
@@ -141,7 +141,7 @@ function subscribe (bot, liveGame, games) {
             LOGGER.error(e);
         }
     });
-    ws.addEventListener('error', (e) => console.error(e));
+    ws.addEventListener('error', (e) => LOGGER.error('Gameday socket error: ' + e.message));
     ws.addEventListener('close', (e) => LOGGER.info('Gameday socket closed: ' + JSON.stringify(e)));
 }
 


### PR DESCRIPTION
We are once in a while getting an extended dose of 500s from the MLB websocket, however we are only retrying 3 times. Just remove the max retry and keep trying with exponential backoff to avoid hanging after only a few tries