### PR TITLE
replace dependency with custom reconnecting websocket

### DIFF
--- a/modules/MLB-API-util.js
+++ b/modules/MLB-API-util.js
@@ -1,5 +1,4 @@
 const globals = require('../config/globals');
-const ReconnectingWebSocket = require('reconnecting-websocket');
 const { LOG_LEVEL } = require('../config/globals');
 const LOGGER = require('./logger')(process.env.LOG_LEVEL?.trim() || LOG_LEVEL.INFO);
 
@@ -61,27 +60,15 @@ module.exports = {
         fetchJson(`https://bdfed.stitch.mlbinfra.com/bdfed/playMetrics/${gamePk}?keyMoments=true&scoringPlays=true&homeRuns=true&strikeouts=true&hardHits=true&highLeverage=false&leadChange=true&winProb=true`),
 
     websocketSubscribe: (gamePk) => {
-        const { WebSocket } = require('ws');
+        const createReconnectingWebSocket = require('./reconnecting-websocket');
         const wsUrl = `wss://ws.statsapi.mlb.com/api/v1/game/push/subscribe/gameday/${gamePk}`;
         LOGGER.debug(wsUrl);
-        const socket = new ReconnectingWebSocket(wsUrl, [], { WebSocket });
-        let heartbeatInterval;
-        /*
-            This is the same ping that Gameday web clients send to the socket server. If you observe the network traffic
-            in the browser, you can see the socket transmits "Gameday5" every 10 seconds or so.
-         */
-        const heartbeat = () => {
-            LOGGER.trace('ping: Gameday5');
-            socket.send('Gameday5');
-        };
-        socket.addEventListener('open', () => {
-            LOGGER.info('Gameday socket opened.');
-            heartbeatInterval = setInterval(heartbeat, globals.GAMEDAY_PING_INTERVAL);
+        return createReconnectingWebSocket(wsUrl, {
+            heartbeatMessage: 'Gameday5',
+            heartbeatInterval: globals.GAMEDAY_PING_INTERVAL,
+            connectionTimeout: 10000,
+            reconnectDelay: 3000
         });
-        socket.addEventListener('close', () => {
-            clearInterval(heartbeatInterval);
-        });
-        return socket;
     },
 
     websocketQueryUpdateId: async (gamePk, updateId, timestamp) => {

--- a/modules/reconnecting-websocket.js
+++ b/modules/reconnecting-websocket.js
@@ -1,0 +1,84 @@
+const { LOG_LEVEL } = require('../config/globals');
+const LOGGER = require('./logger')(process.env.LOG_LEVEL?.trim() || LOG_LEVEL.INFO);
+
+module.exports = (url, {
+    heartbeatMessage,
+    heartbeatInterval,
+    connectionTimeout = 10000,
+    reconnectDelay = 3000,
+    WebSocket: WSClass = require('ws').WebSocket
+} = {}) => {
+    const listeners = { open: [], close: [], message: [], error: [] };
+    let socket = null;
+    let intentionallyClosed = false;
+    let heartbeatTimer = null;
+    let connectTimeout = null;
+
+    const heartbeat = () => {
+        LOGGER.trace(`ping: ${heartbeatMessage}`);
+        if (socket?.readyState === WSClass.OPEN) {
+            socket.send(heartbeatMessage);
+        }
+    };
+
+    const connect = () => {
+        if (intentionallyClosed) {
+            return;
+        }
+        socket = new WSClass(url);
+
+        connectTimeout = setTimeout(() => {
+            LOGGER.debug('WebSocket connection timed out. Retrying...');
+            socket.terminate();
+        }, connectionTimeout);
+
+        socket.on('open', () => {
+            LOGGER.info('WebSocket opened.');
+            clearTimeout(connectTimeout);
+            if (heartbeatMessage && heartbeatInterval) {
+                heartbeatTimer = setInterval(heartbeat, heartbeatInterval);
+            }
+            listeners.open.forEach(fn => fn({}));
+        });
+
+        socket.on('message', (data) => {
+            listeners.message.forEach(fn => fn({ data: data.toString() }));
+        });
+
+        socket.on('error', (e) => {
+            LOGGER.error(`WebSocket error: ${e.message ?? e}`);
+            listeners.error.forEach(fn => fn(e));
+        });
+
+        socket.on('close', () => {
+            clearTimeout(connectTimeout);
+            clearInterval(heartbeatTimer);
+            listeners.close.forEach(fn => fn({}));
+            if (!intentionallyClosed) {
+                LOGGER.info(`WebSocket closed. Reconnecting in ${reconnectDelay}ms.`);
+                setTimeout(connect, reconnectDelay);
+            }
+        });
+    };
+
+    connect();
+
+    return {
+        addEventListener: (event, fn) => {
+            if (listeners[event]) {
+                listeners[event].push(fn);
+            }
+        },
+        send: (data) => {
+            if (socket?.readyState === WSClass.OPEN) {
+                socket.send(data);
+            }
+        },
+        close: () => {
+            intentionallyClosed = true;
+            clearTimeout(connectTimeout);
+            clearInterval(heartbeatTimer);
+            socket?.close();
+        }
+    };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "jasmine": "^5.1.0",
         "jsdom": "^26.0.0",
         "pg": "^8.12.0",
-        "reconnecting-websocket": "^4.4.0",
         "ws": "^8.17.0",
         "ztable": "^1.0.7"
       },
@@ -6128,11 +6127,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/reconnecting-websocket": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/reconnecting-websocket/-/reconnecting-websocket-4.4.0.tgz",
-      "integrity": "sha512-D2E33ceRPga0NvTDhJmphEgJ7FUYF0v4lr1ki0csq06OdlxKfugGzN0dSkxM/NfqCxYELK4KcaTOUOjTV6Dcng=="
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "jasmine": "^5.1.0",
     "jsdom": "^26.0.0",
     "pg": "^8.12.0",
-    "reconnecting-websocket": "^4.4.0",
     "ws": "^8.17.0",
     "ztable": "^1.0.7"
   },

--- a/spec/reconnecting-websocket-spec.js
+++ b/spec/reconnecting-websocket-spec.js
@@ -1,0 +1,188 @@
+const createReconnectingWebSocket = require('../modules/reconnecting-websocket');
+
+class MockWebSocket {
+    constructor (url) {
+        this.url = url;
+        this.readyState = MockWebSocket.CONNECTING;
+        this._listeners = {};
+        this._sent = [];
+        MockWebSocket.instances.push(this);
+    }
+
+    static get CONNECTING () { return 0; }
+    static get OPEN () { return 1; }
+    static get CLOSING () { return 2; }
+    static get CLOSED () { return 3; }
+
+    on (event, fn) {
+        if (!this._listeners[event]) this._listeners[event] = [];
+        this._listeners[event].push(fn);
+    }
+
+    _emit (event, ...args) {
+        (this._listeners[event] || []).forEach(fn => fn(...args));
+    }
+
+    send (data) { this._sent.push(data); }
+    terminate () { this.readyState = MockWebSocket.CLOSED; this._emit('close'); }
+    close () { this.readyState = MockWebSocket.CLOSED; this._emit('close'); }
+
+    simulateOpen () { this.readyState = MockWebSocket.OPEN; this._emit('open'); }
+    simulateMessage (data) { this._emit('message', data); }
+    simulateError (err) { this._emit('error', err); }
+    simulateClose () { this.readyState = MockWebSocket.CLOSED; this._emit('close'); }
+}
+
+const URL = 'wss://example.com/socket';
+const BASE = { WebSocket: MockWebSocket, connectionTimeout: 10000, reconnectDelay: 3000 };
+
+describe('reconnecting-websocket', () => {
+    beforeEach(() => {
+        MockWebSocket.instances = [];
+        jasmine.clock().install();
+    });
+
+    afterEach(() => {
+        jasmine.clock().uninstall();
+    });
+
+    it('should connect immediately on creation', () => {
+        createReconnectingWebSocket(URL, BASE);
+        expect(MockWebSocket.instances.length).toBe(1);
+        expect(MockWebSocket.instances[0].url).toBe(URL);
+    });
+
+    it('should fire open listeners when the socket opens', () => {
+        const ws = createReconnectingWebSocket(URL, BASE);
+        const spy = jasmine.createSpy('open');
+        ws.addEventListener('open', spy);
+        MockWebSocket.instances[0].simulateOpen();
+        expect(spy).toHaveBeenCalledWith({});
+    });
+
+    it('should fire message listeners with the stringified payload', () => {
+        const ws = createReconnectingWebSocket(URL, BASE);
+        const spy = jasmine.createSpy('message');
+        ws.addEventListener('message', spy);
+        MockWebSocket.instances[0].simulateOpen();
+        MockWebSocket.instances[0].simulateMessage({ toString: () => 'hello' });
+        expect(spy).toHaveBeenCalledWith({ data: 'hello' });
+    });
+
+    it('should fire error listeners', () => {
+        const ws = createReconnectingWebSocket(URL, BASE);
+        const spy = jasmine.createSpy('error');
+        ws.addEventListener('error', spy);
+        const err = new Error('oops');
+        MockWebSocket.instances[0].simulateError(err);
+        expect(spy).toHaveBeenCalledWith(err);
+    });
+
+    it('should fire close listeners when the socket closes', () => {
+        const ws = createReconnectingWebSocket(URL, BASE);
+        const spy = jasmine.createSpy('close');
+        ws.addEventListener('close', spy);
+        MockWebSocket.instances[0].simulateOpen();
+        MockWebSocket.instances[0].simulateClose();
+        expect(spy).toHaveBeenCalledWith({});
+    });
+
+    it('should silently ignore addEventListener calls for unknown events', () => {
+        const ws = createReconnectingWebSocket(URL, BASE);
+        expect(() => ws.addEventListener('unknown', () => {})).not.toThrow();
+    });
+
+    it('should reconnect after a server-initiated close', () => {
+        createReconnectingWebSocket(URL, BASE);
+        MockWebSocket.instances[0].simulateOpen();
+        MockWebSocket.instances[0].simulateClose();
+        expect(MockWebSocket.instances.length).toBe(1);
+        jasmine.clock().tick(3000);
+        expect(MockWebSocket.instances.length).toBe(2);
+        expect(MockWebSocket.instances[1].url).toBe(URL);
+    });
+
+    it('should NOT reconnect when close() is called intentionally', () => {
+        const ws = createReconnectingWebSocket(URL, BASE);
+        MockWebSocket.instances[0].simulateOpen();
+        ws.close();
+        jasmine.clock().tick(3000);
+        expect(MockWebSocket.instances.length).toBe(1);
+    });
+
+    it('should terminate and retry on connection timeout', () => {
+        createReconnectingWebSocket(URL, BASE);
+        expect(MockWebSocket.instances.length).toBe(1);
+        jasmine.clock().tick(10000);
+        jasmine.clock().tick(3000);
+        expect(MockWebSocket.instances.length).toBe(2);
+    });
+
+    it('should deliver messages through shared listeners after reconnection', () => {
+        const ws = createReconnectingWebSocket(URL, BASE);
+        const spy = jasmine.createSpy('message');
+        ws.addEventListener('message', spy);
+        MockWebSocket.instances[0].simulateOpen();
+        MockWebSocket.instances[0].simulateClose();
+        jasmine.clock().tick(3000);
+        MockWebSocket.instances[1].simulateOpen();
+        MockWebSocket.instances[1].simulateMessage({ toString: () => 'hello after reconnect' });
+        expect(spy).toHaveBeenCalledWith({ data: 'hello after reconnect' });
+    });
+
+    it('should send a message when the socket is open', () => {
+        const ws = createReconnectingWebSocket(URL, BASE);
+        MockWebSocket.instances[0].simulateOpen();
+        ws.send('hello');
+        expect(MockWebSocket.instances[0]._sent).toContain('hello');
+    });
+
+    it('should not send when the socket is not yet open', () => {
+        const ws = createReconnectingWebSocket(URL, BASE);
+        // socket is still in CONNECTING state
+        ws.send('hello');
+        expect(MockWebSocket.instances[0]._sent.length).toBe(0);
+    });
+
+    it('should send heartbeats at the configured interval while open', () => {
+        createReconnectingWebSocket(URL, { ...BASE, heartbeatMessage: 'ping', heartbeatInterval: 5000 });
+        MockWebSocket.instances[0].simulateOpen();
+        expect(MockWebSocket.instances[0]._sent.length).toBe(0);
+        jasmine.clock().tick(5000);
+        expect(MockWebSocket.instances[0]._sent).toEqual(['ping']);
+        jasmine.clock().tick(5000);
+        expect(MockWebSocket.instances[0]._sent).toEqual(['ping', 'ping']);
+    });
+
+    it('should stop heartbeats when close() is called', () => {
+        const ws = createReconnectingWebSocket(URL, { ...BASE, heartbeatMessage: 'ping', heartbeatInterval: 5000 });
+        MockWebSocket.instances[0].simulateOpen();
+        jasmine.clock().tick(5000);
+        expect(MockWebSocket.instances[0]._sent.length).toBe(1);
+        ws.close();
+        jasmine.clock().tick(5000);
+        expect(MockWebSocket.instances[0]._sent.length).toBe(1);
+    });
+
+    it('should stop heartbeats after a server-side close and resume them on the new socket', () => {
+        createReconnectingWebSocket(URL, { ...BASE, heartbeatMessage: 'ping', heartbeatInterval: 5000 });
+        MockWebSocket.instances[0].simulateOpen();
+        jasmine.clock().tick(5000);
+        expect(MockWebSocket.instances[0]._sent).toEqual(['ping']);
+
+        MockWebSocket.instances[0].simulateClose();
+        jasmine.clock().tick(3000);
+        MockWebSocket.instances[1].simulateOpen();
+        jasmine.clock().tick(5000);
+
+        expect(MockWebSocket.instances[1]._sent).toEqual(['ping']);
+        expect(MockWebSocket.instances[0]._sent.length).toBe(1);
+    });
+
+    it('should not start heartbeats when no heartbeatMessage is configured', () => {
+        createReconnectingWebSocket(URL, BASE); // no heartbeatMessage
+        MockWebSocket.instances[0].simulateOpen();
+        jasmine.clock().tick(10000);
+        expect(MockWebSocket.instances[0]._sent.length).toBe(0);
+    });
+});


### PR DESCRIPTION
The reconnecting websocket library I was using seems to have an issue where it can try and call `.close()` on a socket that is still in the process of connecting, which throws an unhandled error event. 

We just use our own implementation now which always registers an error handler and does not try to close a socket that is connecting (it calls `terminate()` instead which will close the socket regardless of connection status).

fixes #104 

