### PR TITLE
add typing

### DIFF
--- a/database/db.js
+++ b/database/db.js
@@ -1,3 +1,4 @@
+// @ts-check
 const { Pool } = require('pg');
 const fs = require('fs');
 const path = require('path');

--- a/database/queries.js
+++ b/database/queries.js
@@ -1,7 +1,10 @@
+// @ts-check
 const pool = require('./db');
 
 module.exports = {
-
+    /**
+     * @returns {Promise<ChannelSubscription[]>}
+     */
     getAllSubscribedChannels: () => {
         return query({
             text: 'SELECT channel_id, scoring_plays_only, delay FROM gameday_subscribe_channels;',
@@ -9,6 +12,13 @@ module.exports = {
         });
     },
 
+    /**
+     * @param {string} guildId
+     * @param {string} channelId
+     * @param {boolean} scoringPlaysOnly
+     * @param {number} reportingDelay
+     * @returns {Promise<any[]>}
+     */
     addToSubscribedChannels: (guildId, channelId, scoringPlaysOnly, reportingDelay) => {
         return query({
             text: 'INSERT INTO gameday_subscribe_channels VALUES ($1, $2, $3, $4);',
@@ -16,6 +26,13 @@ module.exports = {
         });
     },
 
+    /**
+     * @param {string} guildId
+     * @param {string} channelId
+     * @param {boolean | null} scoringPlaysOnly
+     * @param {number | null} reportingDelay
+     * @returns {Promise<any[]>}
+     */
     updatePlayPreference: (guildId, channelId, scoringPlaysOnly, reportingDelay) => {
         return query({
             text: 'UPDATE gameday_subscribe_channels SET scoring_plays_only' +
@@ -24,6 +41,11 @@ module.exports = {
         });
     },
 
+    /**
+     * @param {string} guildId
+     * @param {string} channelId
+     * @returns {Promise<any[]>}
+     */
     removeFromSubscribedChannels: (guildId, channelId) => {
         return query({
             text: 'DELETE FROM gameday_subscribe_channels WHERE guild_id = $1 AND channel_id = $2;',
@@ -32,6 +54,10 @@ module.exports = {
     }
 };
 
+/**
+ * @param {{ text: string, values: any[] }} queryParams
+ * @returns {Promise<any[]>}
+ */
 function query (queryParams) {
     return new Promise((resolve, reject) => {
         pool.connect().then((client) => client.query(queryParams, (err, res) => {

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "checkJs": true,
+    "strict": false,
+    "noImplicitAny": false,
+    "strictNullChecks": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "lib": ["ES2022"],
+    "typeRoots": ["./node_modules/@types"]
+  },
+  "include": [
+    "**/*.js",
+    "types/**/*.d.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "spec/data/**"
+  ]
+}
+

--- a/main.js
+++ b/main.js
@@ -76,7 +76,7 @@ BOT.on('interactionCreate', async interaction => {
             }
         } catch (replyError) {
             LOGGER.error('Cannot send response to interaction:');
-            LOGGER.error(error);
+            LOGGER.error(replyError);
         }
     }
 });

--- a/modules/MLB-API-util.js
+++ b/modules/MLB-API-util.js
@@ -1,16 +1,35 @@
+// @ts-check
 const globals = require('../config/globals');
 const { LOG_LEVEL } = require('../config/globals');
+/** @type {Logger} */
 const LOGGER = require('./logger')(process.env.LOG_LEVEL?.trim() || LOG_LEVEL.INFO);
 
+/**
+ * @param {string} endpoint
+ * @returns {string}
+ */
 const log = (endpoint) => {
     LOGGER.debug(endpoint);
     return endpoint;
 };
 
+/**
+ * @param {string} endpoint
+ * @returns {Promise<any>}
+ */
 const fetchJson = async (endpoint) => (await fetch(log(endpoint))).json();
+
+/**
+ * @param {string} endpoint
+ * @returns {Promise<ArrayBuffer>}
+ */
 const fetchArrayBuffer = async (endpoint) => (await fetch(log(endpoint))).arrayBuffer();
 
 module.exports = {
+    /**
+     * Returns games within a 48-hour window centred on now (or globals.DATE).
+     * @returns {Promise<ScheduleGame[]>}
+     */
     currentGames: async () => {
         const twentyFourHoursFromNow = globals.DATE ? new Date(globals.DATE) : new Date();
         const twentyFourHoursInThePast = globals.DATE ? new Date(globals.DATE) : new Date();
@@ -26,39 +45,101 @@ module.exports = {
         return games;
     },
 
+    /**
+     * @param {string} [startDate]
+     * @param {string} [endDate]
+     * @param {number} [teamId]
+     * @returns {Promise<ScheduleResponse>}
+     */
     schedule: async (startDate = '', endDate = '', teamId = parseInt(process.env.TEAM_ID)) =>
         fetchJson(`https://statsapi.mlb.com/api/v1/schedule?hydrate=team,lineups&sportId=1&startDate=${startDate}&endDate=${endDate}&teamId=${teamId}`),
 
+    /**
+     * @param {number} gamePk
+     * @param {number} [teamId]
+     * @returns {Promise<ScheduleResponse>}
+     */
     lineup: async (gamePk, teamId = parseInt(process.env.TEAM_ID)) =>
         fetchJson(`https://statsapi.mlb.com/api/v1/schedule?hydrate=lineups&sportId=1&gamePk=${gamePk}&teamId=${teamId}`),
 
+    /**
+     * @param {number} personId
+     * @param {string} statType - gameType code (e.g. "R", "P", "S")
+     * @param {number|string} season
+     * @returns {Promise<PeopleResponse>}
+     */
     hitter: async (personId, statType, season) =>
         fetchJson(`https://statsapi.mlb.com/api/v1/people?personIds=${personId}&hydrate=stats(type=[season,statSplits,lastXGames],group=hitting,gameType=${statType},sitCodes=[vl,vr,risp],limit=7,season=${season})`),
 
+    /**
+     * @param {number} personId
+     * @param {number} lastXGamesLimit
+     * @param {string} statType
+     * @param {number|string} season
+     * @returns {Promise<PeopleResponse>}
+     */
     pitcher: async (personId, lastXGamesLimit, statType, season) =>
         fetchJson(`https://statsapi.mlb.com/api/v1/people?personIds=${personId}&hydrate=stats(type=[season,lastXGames,sabermetrics,seasonAdvanced,expectedStatistics],groups=pitching,limit=${lastXGamesLimit},gameType=${statType},season=${season})`),
 
+    /**
+     * @param {number} gamePk
+     * @param {string[]} [fields]
+     * @returns {Promise<LiveFeedResponse>}
+     */
     liveFeed: async (gamePk, fields = []) =>
         fetchJson(`https://statsapi.mlb.com/api/v1.1/game/${gamePk}/feed/live${fields.length > 0 ? '?fields=' + fields.join() : ''}`),
 
+    /**
+     * Fetches a full live feed via the WebSocket (used after a full_refresh push event).
+     * @param {number} gamePk
+     * @param {string} updateId
+     * @returns {Promise<LiveFeedResponse>}
+     */
     wsLiveFeed: async (gamePk, updateId) =>
         fetchJson(`https://ws.statsapi.mlb.com/api/v1.1/game/${gamePk}/feed/live?language=en&pushUpdateId=${updateId}`),
 
+    /**
+     * @param {number} gamePk
+     * @param {string} timestamp
+     * @returns {Promise<LiveFeedResponse>}
+     */
     liveFeedAtTimestamp: async (gamePk, timestamp) =>
         fetchJson(`https://statsapi.mlb.com/api/v1.1/game/${gamePk}/feed/live?timecode=${timestamp}`),
 
+    /**
+     * @param {number} gamePk
+     * @returns {Promise<MatchupResponse>}
+     */
     matchup: async (gamePk) =>
         fetchJson(`https://bdfed.stitch.mlbinfra.com/bdfed/matchup/${gamePk}?statList=avg&statList=atBats&statList=homeRuns&statList=rbi&statList=ops`),
 
+    /**
+     * @param {number} personId
+     * @param {number} [season]
+     * @returns {Promise<ArrayBuffer>}
+     */
     spot: async (personId, season = new Date().getFullYear()) =>
         fetchArrayBuffer(`https://midfield.mlbstatic.com/v1/people/${personId}/spots/120${season === new Date().getFullYear() ? '' : `?season=${season}`}`),
 
+    /**
+     * @param {number} leagueId
+     * @returns {Promise<StandingsResponse>}
+     */
     standings: async (leagueId) =>
         fetchJson(`https://statsapi.mlb.com/api/v1/standings?leagueId=${leagueId}`),
 
+    /**
+     * @param {number} gamePk
+     * @returns {Promise<any>}
+     */
     playMetrics: async (gamePk) =>
         fetchJson(`https://bdfed.stitch.mlbinfra.com/bdfed/playMetrics/${gamePk}?keyMoments=true&scoringPlays=true&homeRuns=true&strikeouts=true&hardHits=true&highLeverage=false&leadChange=true&winProb=true`),
 
+    /**
+     * Subscribes to the MLB gameday WebSocket feed for the given game.
+     * @param {number} gamePk
+     * @returns {ReconnectingWebSocket}
+     */
     websocketSubscribe: (gamePk) => {
         const createReconnectingWebSocket = require('./reconnecting-websocket');
         const wsUrl = `wss://ws.statsapi.mlb.com/api/v1/game/push/subscribe/gameday/${gamePk}`;
@@ -71,18 +152,40 @@ module.exports = {
         });
     },
 
+    /**
+     * Fetches a diffPatch update from the WS by an updateId.
+     * @param {number} gamePk
+     * @param {string} updateId
+     * @param {string} timestamp
+     * @returns {Promise<DiffPatchResponse[]>}
+     */
     websocketQueryUpdateId: async (gamePk, updateId, timestamp) => {
         const endpoint = `https://ws.statsapi.mlb.com/api/v1.1/game/${gamePk}/feed/live/diffPatch?language=en&startTimecode=${timestamp}&pushUpdateId=${updateId}`;
         LOGGER.trace(endpoint);
         return (await fetch(endpoint)).json();
     },
 
+    /**
+     * @param {number} gamePk
+     * @returns {Promise<string[]>}
+     */
     timestamps: async (gamePk) =>
         fetchJson(`https://statsapi.mlb.com/api/v1.1/game/${gamePk}/feed/live/timestamps`),
 
+    /**
+     * @param {number} gamePk
+     * @returns {Promise<Linescore>}
+     */
     linescore: async (gamePk) =>
         fetchJson(`https://statsapi.mlb.com/api/v1/game/${gamePk}/linescore`),
 
+    /**
+     * Fetches raw Baseball Savant pitch breakdown HTML/text for a pitcher.
+     * Returns an Error on timeout.
+     * @param {number} personId
+     * @param {number|string} season
+     * @returns {Promise<string | Error>}
+     */
     savantPitchData: async (personId, season) => {
         try {
             const endpoint = `https://baseballsavant.mlb.com/player-services/statcast-pitches-breakdown?playerId=${personId}&position=1&hand=&pitchBreakdown=pitches&timeFrame=yearly&pitchType=&count=&updatePitches=true&gameType=RP&season=${season}`;
@@ -96,27 +199,64 @@ module.exports = {
         }
     },
 
+    /**
+     * @param {number} gamePk
+     * @returns {Promise<any>}
+     */
     content: async (gamePk) =>
         fetchJson(`https://statsapi.mlb.com/api/v1/game/${gamePk}/content`),
 
+    /**
+     * @param {number} gamePk
+     * @returns {Promise<any>}
+     */
     statusCheck: async (gamePk) =>
         fetchJson(`https://statsapi.mlb.com/api/v1.1/game/${gamePk}/feed/live?fields=gamePk,gameData,status,abstractGameState,statusCode`),
 
+    /**
+     * Fetches a slim live feed containing only scoring-play descriptions
+     * @param {number} gamePk
+     * @returns {Promise<LiveFeedResponse>}
+     */
     liveFeedSlimPlays: async (gamePk) =>
         fetchJson(`https://statsapi.mlb.com/api/v1.1/game/${gamePk}/feed/live?fields=liveData,scoringPlays,plays,allPlays,about,halfInning,atBatIndex,result,description,playEvents,about,details,description`),
 
+    /**
+     * @param {number[]} personIds
+     * @param {string} statType
+     * @returns {Promise<PeopleResponse>}
+     */
     people: async (personIds, statType) =>
         fetchJson(`https://statsapi.mlb.com/api/v1/people?personIds=${personIds.reduce((acc, value) => acc + ',' + value, '')}&hydrate=stats(type=season,groups=hitting,pitching,gameType=${statType})`),
 
+    /**
+     * @param {number} gamePk
+     * @returns {Promise<any>}
+     */
     liveFeedBoxScoreNamesOnly: async (gamePk) =>
         fetchJson(`https://ws.statsapi.mlb.com/api/v1.1/game/${gamePk}/feed/live?fields=gameData,players,boxscoreName`),
 
+    /**
+     * @param {number} gamePk
+     * @returns {Promise<Boxscore>}
+     */
     boxScore: async (gamePk) =>
         fetchJson(`https://statsapi.mlb.com/api/v1/game/${gamePk}/boxscore`),
 
+    /**
+     * @param {number} gamePk
+     * @param {string} playId
+     * @returns {Promise<XParksResponse>}
+     */
     xParks: async (gamePk, playId) =>
         fetchJson(`https://baseballsavant.mlb.com/gamefeed/x-parks/${gamePk}/${playId}`),
 
+    /**
+     * Returns the Baseball Savant game feed containing stats like xBA, bat speed, and park metrics.
+     * Returns an empty object on failure.
+     * @param {number} gamePk
+     * @returns {Promise<SavantGameFeed | {}>}
+     */
     savantGameFeed: async (gamePk) => {
         try {
             const endpoint = `https://baseballsavant.mlb.com/gf?game_pk=${gamePk}`;
@@ -128,6 +268,13 @@ module.exports = {
         }
     },
 
+    /**
+     * Fetches a player's Baseball Savant page as raw HTML.
+     * Returns an Error on timeout or network failure.
+     * @param {number} personId
+     * @param {'hitting'|'pitching'} type
+     * @returns {Promise<string | Error>}
+     */
     savantPage: async (personId, type) => {
         try {
             const endpoint = globals.SAVANT_PAGE_ENDPOINT(personId, type);
@@ -142,15 +289,31 @@ module.exports = {
         }
     },
 
+    /**
+     * @param {number} teamId
+     * @returns {Promise<any>}
+     */
     team: async (teamId) =>
         fetchJson(`https://statsapi.mlb.com/api/v1/teams/${teamId}`),
 
+    /**
+     * @param {number} teamId
+     * @param {number} [season]
+     * @returns {Promise<any>}
+     */
     fullRoster: async (teamId, season = (new Date().getFullYear())) =>
         fetchJson(`https://statsapi.mlb.com/api/v1/teams/${teamId}/roster?rosterType=fullRoster&season=${season}&hydrate=person`),
 
+    /**
+     * @param {number} [season]
+     * @returns {Promise<PeopleResponse>}
+     */
     players: async (season = (new Date().getFullYear())) =>
         fetchJson(`https://statsapi.mlb.com/api/v1/sports/1/players?fields=people,fullName,lastName,id,currentTeam,primaryPosition,name,code,abbreviation&season=${season}`),
 
+    /**
+     * @returns {Promise<any>}
+     */
     wildcard: async () =>
         fetchJson(`https://bdfed.stitch.mlbinfra.com/bdfed/transform-mlb-standings?&splitPcts=false&numberPcts=false&standingsView=division&sortTemplate=3&season=${new Date().getFullYear()}&leagueIds=103,104&standingsTypes=wildCard&contextTeamId=&date=${(new Date()).toISOString().split('T')[0]}&hydrateAlias=noSchedule&sortDivisions=201,202,200,204,205,203&sortLeagues=103,104,115,114&sortSorts=1`)
 };

--- a/modules/canvas-util.js
+++ b/modules/canvas-util.js
@@ -1,5 +1,14 @@
+// @ts-check
 const { createCanvas, Image } = require('canvas');
+
 module.exports = {
+    /**
+     * Renders one or more ascii-table strings onto a canvas and returns a cropped PNG buffer.
+     * @param {object[]} tables - ascii-table instances
+     * @param {number} canvasWidth
+     * @param {number} canvasHeight
+     * @returns {Buffer}
+     */
     drawSimpleTables: (tables, canvasWidth, canvasHeight) => {
         const width = canvasWidth;
         const height = canvasHeight;
@@ -25,6 +34,13 @@ module.exports = {
         return croppedCanvas.toBuffer('image/png');
     },
 
+    /**
+     * Renders Baseball Savant percentile metric bars alongside a player headshot spot image.
+     * @param {SavantMetric[][]} statCollections - groups of metrics; inner arrays are one stat section each
+     * @param {string[]} collectionLabels - display label for each section
+     * @param {ArrayBuffer} spot - raw image bytes for the player spot
+     * @returns {Buffer}
+     */
     drawSavantTables: (statCollections, collectionLabels, spot) => {
         const width = 500;
         const height = 1000;
@@ -103,6 +119,12 @@ module.exports = {
     }
 };
 
+/**
+ * Creates a repeating diagonal stripe canvas pattern using the given chroma color.
+ * @param {import('canvas').CanvasRenderingContext2D} ctx
+ * @param {any} sliderColor - chroma-js Color object
+ * @returns {CanvasPattern}
+ */
 function createStripePattern (ctx, sliderColor) {
     const stripeCanvas = createCanvas(8, 8);
     const stripeCtx = stripeCanvas.getContext('2d');
@@ -122,6 +144,13 @@ function createStripePattern (ctx, sliderColor) {
     return ctx.createPattern(stripeCanvas, 'repeat');
 }
 
+/**
+ * Returns the bounding box (plus padding) of non-background pixels in a canvas.
+ * @param {import('canvas').CanvasRenderingContext2D} ctx
+ * @param {number} width
+ * @param {number} height
+ * @returns {{ minX: number, minY: number, width: number, height: number } | null}
+ */
 function getBoundingBox (ctx, width, height) {
     const imageData = ctx.getImageData(0, 0, width, height);
     const data = imageData.data;
@@ -156,6 +185,12 @@ function getBoundingBox (ctx, width, height) {
     return { minX, minY, width: maxX - minX + 1, height: maxY - minY + 1 };
 }
 
+/**
+ * Returns a new canvas cropped to the content bounding box.
+ * @param {import('canvas').Canvas} canvas
+ * @param {number} [padding]
+ * @returns {import('canvas').Canvas | null}
+ */
 function cropCanvas (canvas, padding) {
     const ctx = canvas.getContext('2d');
     const boundingBox = getBoundingBox(ctx, canvas.width, canvas.height);

--- a/modules/command-util.js
+++ b/modules/command-util.js
@@ -1,3 +1,4 @@
+// @ts-check
 const { drawSimpleTables, drawSavantTables } = require('./canvas-util');
 const { createCanvas, Image } = require('canvas');
 const globalCache = require('./global-cache');
@@ -12,6 +13,11 @@ const jsdom = require('jsdom');
 const levenshtein = require('./levenshtein');
 
 module.exports = {
+    /**
+     * @param {(Buffer | ArrayBuffer)[]} spots
+     * @param {{ direction?: string, offset?: number, margin?: number, color?: string }} [options]
+     * @returns {Promise<Buffer>}
+     */
     joinPlayerSpots: async (spots, options = {}) => {
         const margin = options.offset ?? options.margin ?? 10;
         const loadImage = (src) => new Promise((resolve, reject) => {
@@ -32,6 +38,12 @@ module.exports = {
         }
         return Promise.resolve(canvas.toBuffer('image/png'));
     },
+
+    /**
+     * @param {Array<{ id: number, primaryPosition: { abbreviation: string } }>} lineup
+     * @param {string} gameType
+     * @returns {Promise<Buffer>}
+     */
     getLineupCardTable: async (lineup, gameType) => {
         const table = new AsciiTable();
         const people = (await mlbAPIUtil.people(lineup.map(lineupPlayer => lineupPlayer.id), gameType)).people;
@@ -63,6 +75,13 @@ module.exports = {
         table.removeBorder();
         return drawSimpleTables([table], 800, 350);
     },
+
+    /**
+     * @param {number | null} probable - personId, or null if TBD
+     * @param {string} statType
+     * @param {number} [season]
+     * @returns {Promise<HydratedProbable>}
+     */
     hydrateProbable: async (probable, statType, season = (new Date().getFullYear())) => {
         const [spot, savant, people] = await Promise.all([
             new Promise((resolve, reject) => {
@@ -96,6 +115,12 @@ module.exports = {
         };
     },
 
+    /**
+     * @param {number | null} hitter - personId, or null if TBD
+     * @param {string} statType
+     * @param {number} [season]
+     * @returns {Promise<HydratedHitter>}
+     */
     hydrateHitter: async (hitter, statType, season = new Date().getFullYear()) => {
         const [spot, stats] = await Promise.all([
             new Promise((resolve, reject) => {
@@ -125,6 +150,12 @@ module.exports = {
         };
     },
 
+    /**
+     * @param {PersonStat | undefined} season
+     * @param {PersonStat | undefined} splitStats
+     * @param {PersonStat | undefined} lastXGamesStats
+     * @returns {string}
+     */
     formatSplits: (season, splitStats, lastXGamesStats) => {
         const vsLeft = (splitStats.splits.find(split => split?.split?.code === 'vl' && !split.team)
             || splitStats.splits.find(split => split?.split?.code === 'vl'));
@@ -160,6 +191,11 @@ module.exports = {
         return formattedSplits;
     },
 
+    /**
+     * @param {GameDisplayable} game
+     * @param {Linescore} linescore
+     * @returns {Buffer}
+     */
     buildLineScoreTable: (game, linescore) => {
         const awayAbbreviation = game.teams.away.team?.abbreviation || game.teams.away.abbreviation;
         const homeAbbreviation = game.teams.home.team?.abbreviation || game.teams.home.abbreviation;
@@ -180,6 +216,14 @@ module.exports = {
         return drawSimpleTables([linescoreTable], 1000, 1000);
     },
 
+    /**
+     * @param {ScheduleGame} game
+     * @param {Boxscore} boxScore
+     * @param {any} boxScoreNames
+     * @param {GameStatus} status
+     * @param {{ customId: string }} boxScoreChoiceToHandle
+     * @returns {Buffer}
+     */
     buildBoxScoreTable: (game, boxScore, boxScoreNames, status, boxScoreChoiceToHandle) => {
         const tables = [];
         const players = boxScore.teams.away.team.id === parseInt(boxScoreChoiceToHandle.customId)
@@ -229,6 +273,11 @@ module.exports = {
         return drawSimpleTables(tables, 600, 800);
     },
 
+    /**
+     * @param {StandingsRecord} standings
+     * @param {string} divisionName
+     * @returns {Buffer}
+     */
     buildStandingsTable: (standings, divisionName) => {
         const centralMap = mapStandings(standings);
         const table = new AsciiTable(divisionName + '\n');
@@ -243,6 +292,12 @@ module.exports = {
         return drawSimpleTables([table], 600, 300);
     },
 
+    /**
+     * @param {StandingsRecord} divisionLeaders
+     * @param {StandingsRecord} wildcard
+     * @param {string} leagueName
+     * @returns {Buffer}
+     */
     buildWildcardTable: (divisionLeaders, wildcard, leagueName) => {
         const divisionLeadersMap = mapStandings(divisionLeaders);
         const wildcardMap = mapStandings(wildcard, true);
@@ -282,6 +337,11 @@ module.exports = {
         return drawSimpleTables([table], 1000, 1000);
     },
 
+    /**
+     * @param {string} savantText
+     * @param {number | string | undefined} season
+     * @returns {{ matchingStatcast?: any, metricSummaryJSON?: Record<string, any>, matchingMetricYear?: string | number } | {}}
+     */
     getStatcastData: (savantText, season) => {
         const statcast = /statcast: \[(?<statcast>.+)],/.exec(savantText)?.groups.statcast;
         const metricSummaries = /metricSummaryStats: {(?<metricSummaries>.+)},/.exec(savantText)?.groups.metricSummaries;
@@ -307,6 +367,12 @@ module.exports = {
         return {};
     },
 
+    /**
+     * @param {Record<string, any>} statcast
+     * @param {Record<string, { avg_metric: number, stddev_metric: number }>} metricSummaries
+     * @param {ArrayBuffer} spot
+     * @returns {Buffer}
+     */
     buildBatterSavantTable: (statcast, metricSummaries, spot) => {
         const value = [
             {
@@ -463,6 +529,12 @@ module.exports = {
         ], spot);
     },
 
+    /**
+     * @param {Record<string, any>} statcast
+     * @param {Record<string, { avg_metric: number, stddev_metric: number }>} metricSummaries
+     * @param {ArrayBuffer} spot
+     * @returns {Buffer}
+     */
     buildPitcherSavantTable: (statcast, metricSummaries, spot) => {
         const value = [
             {
@@ -576,6 +648,11 @@ module.exports = {
         ], spot);
     },
 
+    /**
+     * Returns undefined if no active game; handles double-headers.
+     * @param {import('discord.js').ChatInputCommandInteraction} interaction
+     * @returns {Promise<import('discord.js').ChatInputCommandInteraction | import('discord.js').MessageComponentInteraction | undefined>}
+     */
     screenInteraction: async (interaction) => {
         if (globalCache.values.nearestGames.length === 0 || globalCache.values.nearestGames instanceof Error) {
             await interaction.followUp({
@@ -589,6 +666,12 @@ module.exports = {
         }
     },
 
+    /**
+     * @param {string} playerName
+     * @param {number | undefined} season
+     * @param {number} [ttlMs]
+     * @returns {Promise<Person | null>}
+     */
     findPlayer: async (playerName, season, ttlMs = globals.PLAYER_CACHE_TTL_MS) => {
         const year = season || new Date().getFullYear();
         const people = await module.exports.getPlayersForYear(year, ttlMs);
@@ -599,12 +682,21 @@ module.exports = {
         ) || null;
     },
 
+    /**
+     * @param {import('discord.js').ChatInputCommandInteraction | import('discord.js').MessageComponentInteraction} toHandle
+     * @param {object} options
+     */
     giveFinalCommandResponse: async (toHandle, options) => {
         await toHandle.update
             ? toHandle.update(options)
             : toHandle.followUp(options);
     },
 
+    /**
+     * Handles multiple game object shapes from different API endpoints.
+     * @param {GameDisplayable} game
+     * @returns {string}
+     */
     constructGameDisplayString: (game) => {
         const startTimeTBD = game.gameData?.status?.startTimeTBD || game.status?.startTimeTBD;
         // the game object can be passed here in a few different forms. We just check for them all
@@ -623,6 +715,16 @@ module.exports = {
             }));
     },
 
+    /**
+     * @param {StatSplitStat | undefined} pitchingStats
+     * @param {string[][] | Error | undefined} pitchMix
+     * @param {StatSplitStat | undefined} lastThree
+     * @param {StatSplitStat | undefined} seasonAdvanced
+     * @param {StatSplitStat | undefined} sabermetrics
+     * @param {string} gameType
+     * @param {boolean} [starterMode]
+     * @returns {string}
+     */
     buildPitchingStatsMarkdown: (pitchingStats, pitchMix, lastThree, seasonAdvanced, sabermetrics, gameType, starterMode = true) => {
         let reply = '';
 
@@ -690,6 +792,10 @@ module.exports = {
         return reply;
     },
 
+    /**
+     * @param {string} condition
+     * @returns {string}
+     */
     getWeatherEmoji: (condition) => {
         switch (condition) {
             case 'Clear':
@@ -714,6 +820,11 @@ module.exports = {
         }
     },
 
+    /**
+     * @param {LiveFeedResponse} liveFeed
+     * @param {Play} currentPlayJSON
+     * @returns {string}
+     */
     getScoreString: (liveFeed, currentPlayJSON) => {
         const homeScore = currentPlayJSON.result.homeScore;
         const awayScore = currentPlayJSON.result.awayScore;
@@ -724,6 +835,16 @@ module.exports = {
             liveFeed.gameData.teams.home.abbreviation + ' ' + homeScore + '**');
     },
 
+    /**
+     * @param {Person} pitcher
+     * @param {HydratedProbable} pitcherInfo
+     * @param {string | null} description
+     * @param {string} [statType]
+     * @param {boolean} [savantMode]
+     * @param {number | undefined} [season]
+     * @param {string | undefined} [twoWayLabel]
+     * @returns {import('discord.js').EmbedBuilder}
+     */
     getPitcherEmbed: (pitcher, pitcherInfo, description, statType = 'R', savantMode = false, season = undefined, twoWayLabel = undefined) => {
         const twoWaySuffix = twoWayLabel ? ` (${twoWayLabel})` : '';
         const embed = new EmbedBuilder()
@@ -757,6 +878,16 @@ module.exports = {
         return embed;
     },
 
+    /**
+     * @param {Person} batter
+     * @param {HydratedHitter} batterInfo
+     * @param {string | null} description
+     * @param {string} [statType]
+     * @param {boolean} [savantMode]
+     * @param {number | undefined} [season]
+     * @param {string | undefined} [twoWayLabel]
+     * @returns {import('discord.js').EmbedBuilder}
+     */
     getBatterEmbed: (batter, batterInfo, description, statType = 'R', savantMode = false, season = undefined, twoWayLabel = undefined) => {
         const twoWaySuffix = twoWayLabel ? ` (${twoWayLabel})` : '';
         const yearLabel = season || batterInfo.stats?.season || 'Latest';
@@ -787,6 +918,12 @@ module.exports = {
         return embed;
     },
 
+    /**
+     * Falls back to fuzzy matching if exact name not found.
+     * @param {import('discord.js').ChatInputCommandInteraction} interaction
+     * @param {string} playerName
+     * @returns {Promise<{ player: Person } | undefined>}
+     */
     resolvePlayer: async (interaction, playerName) => {
         const year = interaction.options.getInteger('year') || new Date().getFullYear();
         const removeDiacritics = (str) => str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
@@ -820,6 +957,12 @@ module.exports = {
         return { player };
     },
 
+    /**
+     * @param {import('discord.js').ChatInputCommandInteraction | import('discord.js').MessageComponentInteraction} interaction
+     * @param {{ home: ScheduleGameTeam, away: ScheduleGameTeam }} teams
+     * @param {string} question
+     * @returns {Promise<import('discord.js').MessageComponentInteraction>}
+     */
     getHomeAwayChoice: async (interaction, teams, question) => {
         const buttons = Object.keys(teams).map(key => {
             const emoji = globalCache.values.emojis
@@ -854,6 +997,11 @@ module.exports = {
         }
     },
 
+    /**
+     * @param {{ home: { team: { id: number, name: string } }, away: { team: { id: number, name: string } } }} teams
+     * @param {number} chosenTeamId
+     * @returns {string}
+     */
     getTeamDisplayString: (teams, chosenTeamId) => {
         const emoji = globalCache.values.emojis
             .find(v => v.name.includes(chosenTeamId));
@@ -861,6 +1009,9 @@ module.exports = {
         return `${emoji ? `<:${emoji.name}:${emoji.id}>` : ''} ${team.name}`;
     },
 
+    /**
+     * @param {number} [ttlMs]
+     */
     buildPlayerCache: async (ttlMs = globals.PLAYER_CACHE_TTL_MS) => {
         const currentYear = new Date().getFullYear();
         for (let year = currentYear; year >= globals.PLAYER_STATS_MIN_YEAR; year --) {
@@ -883,6 +1034,11 @@ module.exports = {
         }
     },
 
+    /**
+     * @param {number} year
+     * @param {number} [ttlMs]
+     * @returns {Promise<Person[]>}
+     */
     getPlayersForYear: async (year, ttlMs = globals.PLAYER_CACHE_TTL_MS) => {
         const currentYear = new Date().getFullYear();
         const timestamp = globalCache.values.playerCacheTimestamps[year];
@@ -904,6 +1060,9 @@ module.exports = {
         return globalCache.values.playersByYear[year] || [];
     },
 
+    /**
+     * @param {import('discord.js').AutocompleteInteraction} interaction
+     */
     playerAutocomplete: async (interaction) => {
         try {
             const focusedValue = interaction.options.getFocused().trim().toLowerCase();
@@ -940,6 +1099,10 @@ module.exports = {
         }
     },
 
+    /**
+     * @param {import('discord.js').ChatInputCommandInteraction} interaction
+     * @returns {Promise<import('discord.js').MessageComponentInteraction | undefined>}
+     */
     resolveTwoWayPlayerSelection: async (interaction) => {
         const buttons = [
             new ButtonBuilder()
@@ -966,9 +1129,13 @@ module.exports = {
             });
         }
     }
-
 };
 
+/**
+ * @param {StandingsRecord} standings
+ * @param {boolean} [wildcard]
+ * @returns {StandingsEntry[]}
+ */
 function mapStandings (standings, wildcard = false) {
     return standings.teamRecords.map(teamRecord => {
         return {
@@ -1000,6 +1167,11 @@ function mapStandings (standings, wildcard = false) {
     });
 }
 
+/**
+ * Returns [pitchNames, percentages, MPHs, battingAvgsAgainst].
+ * @param {import('jsdom').JSDOM} dom
+ * @returns {string[][]}
+ */
 function getPitchCollections (dom) {
     const document = dom.window.document;
 
@@ -1044,6 +1216,10 @@ function getPitchCollections (dom) {
     return [pitches, percentages, MPHs, battingAvgsAgainst];
 }
 
+/**
+ * @param {import('discord.js').ChatInputCommandInteraction} interaction
+ * @returns {Promise<import('discord.js').MessageComponentInteraction | undefined>}
+ */
 async function resolveDoubleHeaderSelection (interaction) {
     const buttons = globalCache.values.nearestGames.map(game =>
         new ButtonBuilder()
@@ -1074,6 +1250,11 @@ async function resolveDoubleHeaderSelection (interaction) {
     }
 }
 
+/**
+ * @param {PeopleResponse | undefined} people
+ * @param {string} statType
+ * @returns {PitchingStats}
+ */
 function parsePitchingStats (people, statType) {
     return {
         yearOfStats: findSplit(people?.people[0]?.stats?.find(stat => stat?.type?.displayName === 'season'))?.season,
@@ -1084,10 +1265,19 @@ function parsePitchingStats (people, statType) {
     };
 }
 
+/**
+ * @param {PersonStat | undefined} stat
+ * @returns {StatSplit | undefined}
+ */
 function findSplit (stat) {
     return stat?.splits?.find(s => !s.team) || stat?.splits[0];
 }
 
+/**
+ * @param {SavantMetric[]} statCollection
+ * @param {Record<string, { avg_metric: number, stddev_metric: number }>} metricSummaries
+ * @returns {SavantMetric[]}
+ */
 function addAdditionalDataToStats (statCollection, metricSummaries) {
     const scale = chroma.scale(['#325aa1', '#a8c1c3', '#c91f26']);
     const sliderScale = chroma.scale(['#3661ad', '#b4cfd1', '#d8221f']);
@@ -1114,6 +1304,14 @@ function addAdditionalDataToStats (statCollection, metricSummaries) {
     return statCollection;
 }
 
+/**
+ * @param {string} metric
+ * @param {number | string} value
+ * @param {number} mean
+ * @param {number} standardDeviation
+ * @param {boolean | undefined} shouldInvert
+ * @returns {number}
+ */
 function calculateRoundedPercentileFromNormalDistribution (metric, value, mean, standardDeviation, shouldInvert) {
     if (mean == null || standardDeviation == null || isNaN(value) || isNaN(mean) || isNaN(standardDeviation)) {
         return 0;
@@ -1129,6 +1327,10 @@ function calculateRoundedPercentileFromNormalDistribution (metric, value, mean, 
     );
 }
 
+/**
+ * @param {string} division
+ * @returns {'E' | 'W' | 'C'}
+ */
 function getDivisionAbbreviation (division) {
     if (division.toLowerCase().includes('east')) {
         return 'E';
@@ -1139,6 +1341,10 @@ function getDivisionAbbreviation (division) {
     }
 }
 
+/**
+ * @param {string} gameType
+ * @returns {string}
+ */
 function resolveGameType (gameType) {
     switch (gameType) {
         case 'R':

--- a/modules/current-play-processor.js
+++ b/modules/current-play-processor.js
@@ -1,9 +1,18 @@
+// @ts-check
 const globalCache = require('./global-cache');
 const globals = require('../config/globals');
 const commandUtil = require('./command-util');
 const { CHALLENGE_TYPES } = require('../config/globals');
 
 module.exports = {
+    /**
+     * Two shapes accepted: complete at-bats (have `result`) and sub-events (have `details`).
+     * @param {Play | PlayEvent} currentPlayJSON
+     * @param {LiveFeedWrapper} feed
+     * @param {DiscordEmoji | null} homeTeamEmoji
+     * @param {DiscordEmoji | null} awayTeamEmoji
+     * @returns {ProcessedPlay}
+     */
     process: (currentPlayJSON, feed, homeTeamEmoji, awayTeamEmoji) => {
         let reply = '';
         const halfInning = currentPlayJSON.about?.halfInning || feed.halfInning();
@@ -73,6 +82,15 @@ module.exports = {
     }
 };
 
+/**
+ * @param {string} reply
+ * @param {Play | PlayEvent} currentPlayJSON
+ * @param {string} halfInning
+ * @param {LiveFeedWrapper} feed
+ * @param {DiscordEmoji | null} homeTeamEmoji
+ * @param {DiscordEmoji | null} awayTeamEmoji
+ * @returns {string}
+ */
 function addScore (reply, currentPlayJSON, halfInning, feed, homeTeamEmoji, awayTeamEmoji) {
     reply += '\n';
     let homeScore, awayScore;
@@ -92,6 +110,12 @@ function addScore (reply, currentPlayJSON, halfInning, feed, homeTeamEmoji, away
     return reply;
 }
 
+/**
+ * @param {PlayEvent} lastEvent
+ * @param {string} reply
+ * @param {string} eventType
+ * @returns {string}
+ */
 function addMetrics (lastEvent, reply, eventType) {
     const isSacBunt = globals.SAC_BUNT_EVENT_TYPES.includes(eventType);
     if (lastEvent.hitData.launchSpeed) { // this data can be randomly unavailable

--- a/modules/diff-patch.js
+++ b/modules/diff-patch.js
@@ -1,3 +1,4 @@
+// @ts-check
 const globalCache = require('./global-cache');
 const globals = require('../config/globals');
 const LOGGER = require('./logger')(process.env.LOG_LEVEL?.trim() || globals.LOG_LEVEL.INFO);
@@ -10,6 +11,11 @@ const LOGGER = require('./logger')(process.env.LOG_LEVEL?.trim() || globals.LOG_
     to point to defined values, I have to recursively descend the tree, constructing the object if needed.
  */
 module.exports = {
+    /**
+     * Applies a diffPatch response to the live game feed in globalCache.
+     * Supports RFC-6902 operations: add, replace, remove, copy, move.
+     * @param {DiffPatchResponse} patch
+     */
     hydrate: (patch) => {
         try {
             patch.diff.forEach(difference => {
@@ -80,10 +86,22 @@ module.exports = {
     }
 };
 
+/**
+ * @param {string} slashPath
+ * @returns {string}
+ */
 function toJsonPath (slashPath) {
     return slashPath.replaceAll('/', '.').replaceAll(/\.([0-9]+)/g, '[$1]');
 }
 
+/**
+ * Recursively sets or removes a value by walking `accessors`, constructing
+ * objects/arrays as needed.
+ * @param {Record<string, any>} root
+ * @param {string[]} accessors
+ * @param {unknown} value
+ * @param {DiffPatchDifference['op'] | 'add'} op
+ */
 function setJSONValue (root, accessors, value, op) {
     const currentAccessor = accessors[0];
     if (accessors.length === 1) {

--- a/modules/gameday-util.js
+++ b/modules/gameday-util.js
@@ -1,3 +1,4 @@
+// @ts-check
 const liveFeed = require('./livefeed');
 const globalCache = require('./global-cache');
 const globals = require('../config/globals');
@@ -6,10 +7,19 @@ const mlbAPIUtil = require('./MLB-API-util');
 const LOGGER = require('./logger')(process.env.LOG_LEVEL?.trim() || globals.LOG_LEVEL.INFO);
 
 module.exports = {
+    /**
+     * @param {string} halfInningFull
+     * @returns {'TOP'|'BOT'}
+     */
     deriveHalfInning: (halfInningFull) => {
         return halfInningFull === 'top' ? 'TOP' : 'BOT';
     },
 
+    /**
+     * @param {number} homeScore
+     * @param {number} awayScore
+     * @returns {boolean}
+     */
     didGameEnd: (homeScore, awayScore) => {
         const feed = liveFeed.init(globalCache.values.game.currentLiveFeed);
         return feed.inning() >= 9
@@ -19,6 +29,11 @@ module.exports = {
             );
     },
 
+    /**
+     * @param {number} homeScore
+     * @param {number} awayScore
+     * @returns {boolean}
+     */
     didOurTeamWin: (homeScore, awayScore) => {
         const feed = liveFeed.init(globalCache.values.game.currentLiveFeed);
         return (homeScore > awayScore && feed.homeTeamId() === parseInt(process.env.TEAM_ID))
@@ -47,6 +62,10 @@ module.exports = {
         globalCache.values.game.awayTeamEmoji = globalCache.values.emojis.find(e => e.name.includes(feed.awayTeamId()));
     },
 
+    /**
+     * @param {ProcessedPlay} play
+     * @returns {string}
+     */
     getPitchesStrikesForPitchersInHalfInning: (play) => {
         const feed = liveFeed.init(globalCache.values.game.currentLiveFeed);
         const boxscore = feed.boxscore();
@@ -62,6 +81,7 @@ module.exports = {
             `${value?.person.fullName} (${value?.stats.pitching.numberOfPitches} P - ${value?.stats.pitching.strikes} S)${pitchersFromThisHalfInning.indexOf(value) === pitchersFromThisHalfInning.length - 1 ? '' : ', '}`, '')}\n`;
     },
 
+    /** @returns {string} */
     getDueUp: () => {
         const feed = liveFeed.init(globalCache.values.game.currentLiveFeed);
         const linescore = feed.linescore();
@@ -75,6 +95,13 @@ module.exports = {
             inHoleIndex + '. ' + linescore.offense?.inHole?.fullName;
     },
 
+    /**
+     * Returns null if data not yet available (caller should retry), '' if no annotation needed.
+     * @param {number} gamePk
+     * @param {string} playId
+     * @param {number} numberOfParks
+     * @returns {Promise<string | null>}
+     */
     getXParks: async (gamePk, playId, numberOfParks) => {
         const feed = liveFeed.init(globalCache.values.game.currentLiveFeed);
         const isHome = feed.homeTeamId() === parseInt(process.env.TEAM_ID);

--- a/modules/gameday.js
+++ b/modules/gameday.js
@@ -1,12 +1,8 @@
+// @ts-check
 /**
- * This component concerns subscribing to MLB.com's websocket feed for a live game and in turn reporting that to subscribed Discord channels.
- * It does that very consistently well, and it took a lot of work to get to that point. But it is not perfect, and I don't think it ever will be.
- * Once in a while, you will see a missed event, or a misreported event, or some other weird bug. From what I have observed, that is a consequence of MLB's
- * data feed, which also occasionally makes mistakes. In fact, I have witnessed them sending rare "correction" events live in the wild. And while
- * corrections can be handled nicely on a webpage, once my bot has broadcast an event out to Discord channels, I can't really
- * correct it, at least not easily. I don't want to be in the business of trying to fish for and correct previously sent messages - that
- * is too much overhead and too much complexity for not enough payoff. So, all this to say, if you come into this component
- * looking to perfect it, while I'm sure there are improvements to make, just be aware: the API we are consuming is not perfect either.
+ * Subscribes to MLB's WebSocket gameday feed and reports live plays to Discord channels. Note: MLB's live game API
+ * is not perfect. Once in a while we may miss an event or receive and report data that is off in some way. We've done our
+ * best to mitigate this. By-and-large we are consistent, stable, and accurate, but it's not foolproof.
  */
 
 const mlbAPIUtil = require('./MLB-API-util');
@@ -19,7 +15,7 @@ const LOGGER = require('./logger')(process.env.LOG_LEVEL?.trim() || globals.LOG_
 const liveFeed = require('./livefeed');
 const gamedayUtil = require('./gameday-util');
 
-// Shared queue for savant polling: playId -> { gamePk, messages, hitDistance, embed, activeTimers, attempts }
+/** @type {Map<string, SavantQueueEntry>} */
 const savantQueue = new Map();
 let savantLoopRunning = false;
 
@@ -40,6 +36,10 @@ module.exports = {
     get savantLoopRunning () { return savantLoopRunning; }
 };
 
+/**
+ * Starts the polling loop that watches for a game to go live, then hands off to subscribe().
+ * @param {import('discord.js').Client} bot
+ */
 async function statusPoll (bot) {
     const pollingFunction = async () => {
         LOGGER.info('Games: polling...');
@@ -78,12 +78,19 @@ async function statusPoll (bot) {
     await pollingFunction();
 }
 
+/**
+ * Subscribes to the MLB gameday WebSocket for the given game and begins processing events.
+ * @param {import('discord.js').Client} bot
+ * @param {ScheduleGame} liveGame
+ * @param {ScheduleGame[]} games
+ */
 function subscribe (bot, liveGame, games) {
     LOGGER.trace('Gameday: subscribing...');
     const ws = mlbAPIUtil.websocketSubscribe(liveGame.gamePk);
     ws.addEventListener('message', async (e) => {
         try {
             const feed = liveFeed.init(globalCache.values.game.currentLiveFeed);
+            /** @type {GamedaySocketEvent} */
             const eventJSON = JSON.parse(e.data);
             /*
                 Once in a while, Gameday will send us duplicate messages. They have different updateIds, but the exact
@@ -145,6 +152,11 @@ function subscribe (bot, liveGame, games) {
     ws.addEventListener('close', (e) => LOGGER.info('Gameday socket closed: ' + JSON.stringify(e)));
 }
 
+/**
+ * Processes all at-bats and events since the last reported index and pushes them to Discord.
+ * @param {import('discord.js').Client} bot
+ * @param {number} gamePk
+ */
 async function reportPlays (bot, gamePk) {
     const feed = liveFeed.init(globalCache.values.game.currentLiveFeed);
     const currentPlay = feed.currentPlay();
@@ -182,6 +194,13 @@ async function reportPlays (bot, gamePk) {
     ), gamePk, atBatIndex);
 }
 
+/**
+ * Reports any notable play-events within an at-bat that haven't been reported yet.
+ * @param {Play} atBat
+ * @param {import('discord.js').Client} bot
+ * @param {number} gamePk
+ * @param {number} atBatIndex
+ */
 async function reportAnyMissedEvents (atBat, bot, gamePk, atBatIndex) {
     const feed = liveFeed.init(globalCache.values.game.currentLiveFeed);
     const missedEventsToReport = atBat.playEvents?.filter(event => globals.EVENT_WHITELIST.includes(event?.details?.eventType)
@@ -229,6 +248,14 @@ function alreadyReported (description, atBatIndex) {
     });
 }
 
+/**
+ * Sends a processed play to all subscribed Discord channels, respecting per-channel delay settings.
+ * @param {import('discord.js').Client} bot
+ * @param {ProcessedPlay} play
+ * @param {number} gamePk
+ * @param {number} atBatIndex
+ * @param {boolean} [includeTitle]
+ */
 async function processAndPushPlay (bot, play, gamePk, atBatIndex, includeTitle = true) {
     if (play.reply
         && play.reply.length > 0
@@ -278,6 +305,17 @@ async function processAndPushPlay (bot, play, gamePk, atBatIndex, includeTitle =
     }
 }
 
+/**
+ * Builds a Discord EmbedBuilder for the given processed play.
+ * @param {ProcessedPlay} play
+ * @param {LiveFeedWrapper} feed
+ * @param {boolean} includeTitle
+ * @param {string} homeTeamColor
+ * @param {string} awayTeamColor
+ * @param {DiscordEmoji | null} homeTeamEmoji
+ * @param {DiscordEmoji | null} awayTeamEmoji
+ * @returns {import('discord.js').EmbedBuilder}
+ */
 function constructPlayEmbed (play, feed, includeTitle, homeTeamColor, awayTeamColor, homeTeamEmoji, awayTeamEmoji) {
     const halfInning = play.halfInning || feed.halfInning();
     const inning = play.inning || feed.inning();
@@ -306,6 +344,12 @@ function constructPlayEmbed (play, feed, includeTitle, homeTeamColor, awayTeamCo
     return embed;
 }
 
+/**
+ * Sends the embed to a channel immediately and tracks the Discord message for later edits.
+ * @param {import('discord.js').TextBasedChannel} returnedChannel
+ * @param {import('discord.js').EmbedBuilder} embed
+ * @param {MessageEntry} message
+ */
 async function sendMessage (returnedChannel, embed, message) {
     LOGGER.debug('Sending!');
     try {
@@ -318,6 +362,15 @@ async function sendMessage (returnedChannel, embed, message) {
     }
 }
 
+/**
+ * Schedules an embed send for a channel with a configured delay.
+ * @param {ProcessedPlay} play
+ * @param {number} gamePk
+ * @param {ChannelSubscription} channelSubscription
+ * @param {import('discord.js').TextBasedChannel} returnedChannel
+ * @param {import('discord.js').EmbedBuilder} embed
+ * @param {MessageEntry} message
+ */
 function sendDelayedMessage (play, gamePk, channelSubscription, returnedChannel, embed, message) {
     setTimeout(async () => {
         LOGGER.debug('Sending!');
@@ -331,6 +384,13 @@ function sendDelayedMessage (play, gamePk, channelSubscription, returnedChannel,
     }, channelSubscription.delay * 1000);
 }
 
+/**
+ * Decides whether to poll for Savant metrics, and kicks off polling if applicable.
+ * @param {ProcessedPlay} play
+ * @param {MessageEntry[]} messages
+ * @param {number} gamePk
+ * @param {import('discord.js').EmbedBuilder} embed
+ */
 async function maybePopulateAdvancedStatcastMetrics (play, messages, gamePk, embed) {
     if (play.isInPlay && play.metricsAvailable) {
         if (play.playId) {
@@ -351,6 +411,11 @@ async function maybePopulateAdvancedStatcastMetrics (play, messages, gamePk, emb
     }
 }
 
+/**
+ * Replaces all "Pending..." placeholders in the embed with "Not Available." and marks messages done.
+ * @param {MessageEntry[]} messages
+ * @param {import('discord.js').EmbedBuilder} embed
+ */
 function notifySavantDataUnavailable (messages, embed) {
     embed.data.description = embed.data.description.replaceAll('Pending...', 'Not Available.');
     editMessages(messages, embed);
@@ -359,6 +424,12 @@ function notifySavantDataUnavailable (messages, embed) {
     }
 }
 
+/**
+ * Edits all already-sent Discord messages in the list with the updated embed.
+ * @param {MessageEntry[]} messages
+ * @param {import('discord.js').EmbedBuilder} embed
+ * @param {string} [logLabel]
+ */
 function editMessages (messages, embed, logLabel = 'Edited') {
     for (const message of messages) {
         if (message.discordMessage && !message.doneEditing) {
@@ -372,6 +443,12 @@ function editMessages (messages, embed, logLabel = 'Edited') {
     }
 }
 
+/**
+ * Edits all Discord messages (including delayed ones) with updated park data.
+ * @param {MessageEntry[]} messages
+ * @param {import('discord.js').EmbedBuilder} embed
+ * @param {string} logLabel
+ */
 function editMessagesWithXParks (messages, embed, logLabel) {
     for (const message of messages) {
         if (message.discordMessage) {
@@ -382,8 +459,14 @@ function editMessagesWithXParks (messages, embed, logLabel) {
     }
 }
 
-/* Enqueues a play for savant data polling. A single shared polling loop handles all queued plays. If the loop is already
-    running, the play is simply added to the queue. If not, the loop is started first. */
+/**
+ * Enqueues a play and starts the shared polling loop if not already running.
+ * @param {number} gamePk
+ * @param {string} playId
+ * @param {MessageEntry[]} messages
+ * @param {number | undefined} hitDistance
+ * @param {import('discord.js').EmbedBuilder} embed
+ */
 async function pollForSavantData (gamePk, playId, messages, hitDistance, embed) {
     const activeTimers = new Set();
     const startTimer = (label) => { console.time(label); activeTimers.add(label); };
@@ -403,8 +486,6 @@ async function pollForSavantData (gamePk, playId, messages, hitDistance, embed) 
     }
 }
 
-/* Single shared polling loop for all queued savant plays. Fetches the savant game feed once per iteration
-   and processes all queued plays against it. Stops when the queue is empty. */
 async function runSavantPollingLoop () {
     const pollingFunction = async () => {
         if (savantQueue.size === 0) {
@@ -451,10 +532,14 @@ async function runSavantPollingLoop () {
     await pollingFunction();
 }
 
-/*
-    When XParks data wasn't ready at the time of first edit, poll the endpoint until it becomes available,
-    then edit messages with the park details appended to the existing HR/Park description.
-*/
+/**
+ * @param {number} gamePk
+ * @param {string} playId
+ * @param {number} numberOfParks
+ * @param {string} baseHRParkDescription
+ * @param {MessageEntry[]} messages
+ * @param {import('discord.js').EmbedBuilder} embed
+ */
 async function pollForXParksAndEdit (gamePk, playId, numberOfParks, baseHRParkDescription, messages, embed) {
     let attempts = 1;
     let currentInterval = globals.SAVANT_XPARKS_POLLING_INTERVAL;
@@ -486,10 +571,14 @@ async function pollForXParksAndEdit (gamePk, playId, numberOfParks, baseHRParkDe
     await pollingFunction();
 }
 
-/* Takes a "play" from the baseball savant game feed and attempts to update any already-sent Discord messages with the metrics.
-    Notably, the list of messages can include messages with a reporting delay that have not yet been sent. We only attempt
-    to edit messages that have been sent.
-*/
+/**
+ * @param {SavantPlayMetrics} matchingPlay
+ * @param {MessageEntry[]} messages
+ * @param {string} playId
+ * @param {number | undefined} hitDistance
+ * @param {import('discord.js').EmbedBuilder} embed
+ * @param {Set<string>} [activeTimers]
+ */
 async function processMatchingPlay (matchingPlay, messages, playId, hitDistance, embed, activeTimers = new Set()) {
     const endTimer = (label) => { if (activeTimers.has(label)) { console.timeEnd(label); activeTimers.delete(label); } };
     const feed = liveFeed.init(globalCache.values.game.currentLiveFeed);

--- a/modules/global-cache.js
+++ b/modules/global-cache.js
@@ -1,3 +1,6 @@
+// @ts-check
+
+/** @returns {GameCache} */
 const gameDefaults = () => ({
     currentLiveFeed: null,
     currentGamePk: null,
@@ -15,6 +18,7 @@ const gameDefaults = () => ({
     lastSocketMessageLength: null
 });
 
+/** @type {GlobalCacheValues} */
 const values = {
     nearestGames: null,
     currentGames: null,

--- a/modules/interaction-handlers.js
+++ b/modules/interaction-handlers.js
@@ -1,3 +1,4 @@
+// @ts-check
 const { AttachmentBuilder, EmbedBuilder, PermissionsBitField } = require('discord.js');
 const globalCache = require('./global-cache');
 const mlbAPIUtil = require('./MLB-API-util');
@@ -10,13 +11,17 @@ const exampleLiveFeed = require('../spec/data/example-live-feeds/live-feed-2024'
 const liveFeed = require('./livefeed');
 const currentPlayProcessor = require('./current-play-processor');
 
+/** @typedef {import('discord.js').ChatInputCommandInteraction} SlashInteraction */
+
 module.exports = {
 
+    /** @param {SlashInteraction} interaction */
     helpHandler: async (interaction) => {
         console.info(`HELP command invoked by guild: ${interaction.guildId}`);
-        interaction.reply({ content: globals.HELP_MESSAGE, ephemeral: true });
+        await interaction.reply({ content: globals.HELP_MESSAGE, ephemeral: true });
     },
 
+    /** @param {SlashInteraction} interaction */
     startersHandler: async (interaction) => {
         console.info(`STARTERS command invoked by guild: ${interaction.guildId}`);
         await interaction.deferReply();
@@ -78,6 +83,7 @@ module.exports = {
             });
     },
 
+    /** @param {SlashInteraction} interaction */
     scheduleHandler: async (interaction) => {
         console.info(`SCHEDULE command invoked by guild: ${interaction.guildId}`);
         await interaction.deferReply();
@@ -129,6 +135,7 @@ module.exports = {
         }
     },
 
+    /** @param {SlashInteraction} interaction */
     standingsHandler: async (interaction) => {
         await interaction.deferReply();
         console.info(`STANDINGS command invoked by guild: ${interaction.guildId}`);
@@ -160,6 +167,7 @@ module.exports = {
         });
     },
 
+    /** @param {SlashInteraction} interaction */
     wildcardHandler: async (interaction) => {
         await interaction.deferReply();
         console.info(`WILDCARD command invoked by guild: ${interaction.guildId}`);
@@ -184,6 +192,7 @@ module.exports = {
         }
     },
 
+    /** @param {SlashInteraction} interaction */
     subscribeGamedayHandler: async (interaction) => {
         console.info(`SUBSCRIBE GAMEDAY command invoked by guild: ${interaction.guildId}`);
         if (!interaction.member.permissions.has(PermissionsBitField.Flags.ManageMessages)) {
@@ -230,6 +239,7 @@ module.exports = {
         }
     },
 
+    /** @param {SlashInteraction} interaction */
     testGamedayReportingHandler: async (interaction) => {
         console.info(`TEST GAMEDAY REPORTING command invoked by guild: ${interaction.guildId}`);
         if (!interaction.member.permissions.has(PermissionsBitField.Flags.ManageMessages)) {
@@ -279,6 +289,7 @@ module.exports = {
         }
     },
 
+    /** @param {SlashInteraction} interaction */
     gamedayPreferenceHandler: async (interaction) => {
         console.info(`GAMEDAY PREFERENCE command invoked by guild: ${interaction.guildId}`);
         if (!interaction.member.permissions.has(PermissionsBitField.Flags.ManageMessages)) {
@@ -327,6 +338,7 @@ module.exports = {
         }
     },
 
+    /** @param {SlashInteraction} interaction */
     unSubscribeGamedayHandler: async (interaction) => {
         console.info(`UNSUBSCRIBE GAMEDAY command invoked by guild: ${interaction.guildId}`);
         if (!interaction.member.permissions.has(PermissionsBitField.Flags.ManageMessages)) {
@@ -350,6 +362,7 @@ module.exports = {
         globalCache.values.subscribedChannels = await queries.getAllSubscribedChannels();
     },
 
+    /** @param {SlashInteraction} interaction */
     linescoreHandler: async (interaction) => {
         console.info(`LINESCORE command invoked by guild: ${interaction.guildId}`);
         if (!globalCache.values.game.isDoubleHeader) {
@@ -385,6 +398,7 @@ module.exports = {
         }
     },
 
+    /** @param {SlashInteraction} interaction */
     boxScoreHandler: async (interaction) => {
         console.info(`BOXSCORE command invoked by guild: ${interaction.guildId}`);
         if (!globalCache.values.game.isDoubleHeader) {
@@ -437,6 +451,7 @@ module.exports = {
         }
     },
 
+    /** @param {SlashInteraction} interaction */
     lineupHandler: async (interaction) => {
         console.info(`LINEUP command invoked by guild: ${interaction.guildId}`);
         if (!globalCache.values.game.isDoubleHeader) {
@@ -484,6 +499,7 @@ module.exports = {
         }
     },
 
+    /** @param {SlashInteraction} interaction */
     highlightsHandler: async (interaction) => {
         console.info(`HIGHLIGHTS command invoked by guild: ${interaction.guildId}`);
         if (!globalCache.values.game.isDoubleHeader) {
@@ -512,6 +528,7 @@ module.exports = {
         }
     },
 
+    /** @param {SlashInteraction} interaction */
     playerHandler: async (interaction) => {
         console.info(`PLAYER command invoked by guild: ${interaction.guildId}`);
         await interaction.deferReply();
@@ -582,6 +599,7 @@ module.exports = {
         }
     },
 
+    /** @param {SlashInteraction} interaction */
     playerSavantHandler: async (interaction) => {
         console.info(`PLAYER SAVANT command invoked by guild: ${interaction.guildId}`);
         await interaction.deferReply();
@@ -651,6 +669,7 @@ module.exports = {
         }
     },
 
+    /** @param {SlashInteraction} interaction */
     scoringPlaysHandler: async (interaction) => {
         console.info(`SCORING PLAYS command invoked by guild: ${interaction.guildId}`);
         if (!globalCache.values.game.isDoubleHeader) {
@@ -708,6 +727,7 @@ module.exports = {
         }
     },
 
+    /** @param {SlashInteraction} interaction */
     attendanceHandler: async (interaction) => {
         console.info(`ATTENDANCE command invoked by guild: ${interaction.guildId}`);
         if (!globalCache.values.game.isDoubleHeader) {
@@ -736,6 +756,7 @@ module.exports = {
         }
     },
 
+    /** @param {SlashInteraction} interaction */
     weatherHandler: async (interaction) => {
         console.info(`WEATHER command invoked by guild: ${interaction.guildId}`);
         if (!globalCache.values.game.isDoubleHeader) {
@@ -765,6 +786,7 @@ module.exports = {
         }
     },
 
+    /** @param {SlashInteraction} interaction */
     bullpenHandler: async (interaction) => {
         console.info(`BULLPEN command invoked by guild: ${interaction.guildId}`);
         if (!globalCache.values.game.isDoubleHeader) {

--- a/modules/livefeed.js
+++ b/modules/livefeed.js
@@ -1,4 +1,11 @@
+// @ts-check
+
 module.exports = {
+    /**
+     * Wraps a raw live feed response with typed accessor methods.
+     * @param {LiveFeedResponse} liveFeed
+     * @returns {LiveFeedWrapper}
+     */
     init: (liveFeed) => {
         return {
             gamePk: () => {

--- a/modules/logger.js
+++ b/modules/logger.js
@@ -1,5 +1,7 @@
+// @ts-check
 const { LOG_LEVEL } = require('../config/globals');
 
+/** @returns {Logger} */
 module.exports = function (logLevel = LOG_LEVEL.INFO) {
     return {
         logLevel,

--- a/modules/reconnecting-websocket.js
+++ b/modules/reconnecting-websocket.js
@@ -1,6 +1,11 @@
+// @ts-check
 const { LOG_LEVEL } = require('../config/globals');
 const LOGGER = require('./logger')(process.env.LOG_LEVEL?.trim() || LOG_LEVEL.INFO);
 
+/**
+ * @param {string} url
+ * @param {ReconnectingWebSocketOptions} [options]
+ */
 module.exports = (url, {
     heartbeatMessage,
     heartbeatInterval,
@@ -9,11 +14,16 @@ module.exports = (url, {
     WebSocket: WSClass = require('ws').WebSocket
 } = {}) => {
     const listeners = { open: [], close: [], message: [], error: [] };
+    /** @type {import('ws').WebSocket | null} */
     let socket = null;
     let intentionallyClosed = false;
     let heartbeatTimer = null;
     let connectTimeout = null;
 
+    /**
+     * @param {() => void} fn
+     * @returns {void}
+     */
     const heartbeat = () => {
         LOGGER.trace(`ping: ${heartbeatMessage}`);
         if (socket?.readyState === WSClass.OPEN) {
@@ -21,6 +31,9 @@ module.exports = (url, {
         }
     };
 
+    /**
+     * @returns {void}
+     */
     const connect = () => {
         if (intentionallyClosed) {
             return;
@@ -63,12 +76,18 @@ module.exports = (url, {
 
     connect();
 
+    /** @returns {ReconnectingWebSocket} */
     return {
+        /**
+         * @param {WebSocketEventType} event
+         * @param {(event: any) => void} fn
+         */
         addEventListener: (event, fn) => {
             if (listeners[event]) {
                 listeners[event].push(fn);
             }
         },
+        /** @param {string} data */
         send: (data) => {
             if (socket?.readyState === WSClass.OPEN) {
                 socket.send(data);

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@babel/eslint-parser": "^7.16.5",
         "@babel/plugin-transform-object-assign": "^7.16.5",
         "@babel/preset-env": "^7.16.5",
+        "@types/node": "^26.0.0",
         "babel-eslint": "^10.1.0",
         "babel-loader": "^8.2.3",
         "eslint": "^8.20.0",
@@ -2079,11 +2080,11 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "25.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
-      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/ws": {
@@ -7291,9 +7292,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@babel/eslint-parser": "^7.16.5",
     "@babel/plugin-transform-object-assign": "^7.16.5",
     "@babel/preset-env": "^7.16.5",
+    "@types/node": "^26.0.0",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.2.3",
     "eslint": "^8.20.0",

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -1,0 +1,208 @@
+/** Application-specific ambient type declarations. */
+
+interface DiscordEmoji { name: string; id: string }
+
+interface ChannelSubscription {
+    channel_id: string;
+    scoring_plays_only: boolean;
+    delay: number; // seconds
+}
+
+interface GameCache {
+    currentLiveFeed: LiveFeedResponse | null;
+    currentGamePk: number | null;
+    isDoubleHeader: boolean | null;
+    lastReportedCompleteAtBatIndex: number; // -1 when none yet
+    lastReportedPlayDescription: string | null;
+    startReported: boolean;
+    reportedDescriptions: Array<{ description: string; atBatIndex: number }>;
+    homeTeamColor: string | null;
+    awayTeamColor: string | null;
+    homeTeamEmoji: DiscordEmoji | null;
+    awayTeamEmoji: DiscordEmoji | null;
+    finished: boolean;
+    lastSocketMessageTimestamp: string | null;
+    lastSocketMessageLength: number | null;
+}
+
+interface GlobalCacheValues {
+    nearestGames: ScheduleGame[] | null;
+    currentGames: ScheduleGame[] | null;
+    subscribedChannels: ChannelSubscription[];
+    emojis: DiscordEmoji[] | null;
+    playersByYear: Record<number, Person[]>;
+    playerCacheTimestamps: Record<number, number>;
+    game: GameCache;
+}
+
+/** Typed accessor wrapper returned by `livefeed.init(rawFeed)`. */
+interface LiveFeedWrapper {
+    gamePk(): number;
+    timestamp(): string;
+    inning(): number;
+    halfInning(): string;
+    awayAbbreviation(): string;
+    homeAbbreviation(): string;
+    homeTeamId(): number;
+    awayTeamId(): number;
+    homeTeamVenue(): { id: number; name: string };
+    awayTeamVenue(): { id: number; name: string };
+    currentPlay(): Play;
+    allPlays(): Play[];
+    linescore(): Linescore;
+    boxscore(): Boxscore;
+    homeTeamScore(): number;
+    awayTeamScore(): number;
+    currentBatterBatSide(): string;
+    players(): Record<string, Person>;
+    weather(): { condition: string; temp: string; wind: string };
+    absChallenges(): AbsChallenges | undefined;
+    venueName(): string;
+}
+
+/**
+ * Output of `currentPlayProcessor.process()`.
+ * Covers both completed at-bats (have `result`) and sub-events (have `details`).
+ */
+interface ProcessedPlay {
+    reply: string;
+    isStartEvent: PlayEvent | undefined;
+    isOut: boolean;
+    outs: number;
+    homeScore: number;
+    awayScore: number;
+    isComplete: boolean;
+    description: string;
+    event: string;
+    eventType: string;
+    inning: number;
+    halfInning: string;
+    isScoringPlay: boolean;
+    isInPlay: boolean;
+    playId: string | undefined;
+    metricsAvailable: boolean;
+    hitDistance: number | undefined;
+    hasReview: boolean;
+    reviewInProgress: boolean;
+    currentPitcherId: number | undefined;
+}
+
+/** Tracked so it can be edited asynchronously when Statcast data arrives. */
+interface MessageEntry {
+    channel: import('discord.js').TextBasedChannel;
+    play: ProcessedPlay;
+    delayed: boolean;
+    doneEditing: boolean;
+    discordMessage?: import('discord.js').Message;
+}
+
+interface SavantQueueEntry {
+    gamePk: number;
+    messages: MessageEntry[];
+    hitDistance: number | undefined;
+    embed: import('discord.js').EmbedBuilder;
+    activeTimers: Set<string>;
+    attempts: number;
+}
+
+interface PitchingStats {
+    yearOfStats: string | undefined;
+    season: StatSplitStat | undefined;
+    lastXGames: StatSplitStat | undefined;
+    seasonAdvanced: StatSplitStat | undefined;
+    sabermetrics: StatSplitStat | undefined;
+}
+
+interface HydratedProbable {
+    spot: Buffer;
+    fullName: string | undefined;
+    pitchMix: string[][] | Error; // [pitchNames, percentages, MPHs, battingAvgs]
+    pitchingStats: PitchingStats;
+    handedness: string | undefined;
+}
+
+interface HydratedHitter {
+    spot: Buffer;
+    stats: Person;
+}
+
+/** Metric row for `buildBatterSavantTable` / `buildPitcherSavantTable`. Enriched by `addAdditionalDataToStats`. */
+interface SavantMetric {
+    label: string;
+    value: number | string | null | undefined;
+    metric: string;
+    percentile: number;
+    shouldInvert?: boolean;
+    isQualified?: boolean;
+    sliderColor?: any; // chroma-js Color
+    circleColor?: any;
+}
+
+/** Normalised row from internal `mapStandings()`. */
+interface StandingsEntry {
+    name: string;
+    wins: number;
+    losses: number;
+    pct: string;
+    gamesBack: string;
+    homeRecord: string;
+    awayRecord: string;
+    lastTen: string;
+    streak: string;
+}
+
+type WebSocketEventType = 'open' | 'close' | 'message' | 'error';
+
+interface ReconnectingWebSocket {
+    addEventListener(event: WebSocketEventType, fn: (event: any) => void): void;
+    send(data: string): void;
+    close(): void;
+}
+
+interface ReconnectingWebSocketOptions {
+    heartbeatMessage?: string;
+    heartbeatInterval?: number;
+    connectionTimeout?: number;
+    reconnectDelay?: number;
+    WebSocket?: typeof import('ws').WebSocket;
+}
+
+interface Logger {
+    logLevel: string;
+    info(message?: unknown): void;
+    error(message?: unknown): void;
+    warn(message?: unknown): void;
+    debug(message?: unknown): void;
+    trace(message?: unknown): void;
+}
+
+interface TeamConfig {
+    id: number;
+    name: string;
+    abbreviation: string;
+    primaryColor: string;
+    secondaryColor: string;
+}
+
+/**
+ * A game passed to display helpers. It can arrive in several shapes depending
+ * on which endpoint fetched it, so all fields are optional.
+ */
+interface GameDisplayable {
+    gamePk?: number;
+    gameDate?: string;
+    officialDate?: string;
+    status?: { statusCode?: string; abstractGameState?: string; codedGameState?: string; startTimeTBD?: boolean };
+    gameType?: string;
+    teams?: {
+        home?: { team?: { id?: number; abbreviation?: string; name?: string }; abbreviation?: string };
+        away?: { team?: { id?: number; abbreviation?: string; name?: string }; abbreviation?: string };
+    };
+    gameData?: {
+        status?: { startTimeTBD?: boolean };
+        datetime?: { dateTime?: string };
+        teams?: { home?: { abbreviation?: string }; away?: { abbreviation?: string } };
+    };
+    datetime?: { dateTime?: string };
+}
+

--- a/types/mlb-api.d.ts
+++ b/types/mlb-api.d.ts
@@ -1,0 +1,302 @@
+/**
+ * MLB Stats API ambient type declarations.
+ * Reference: https://github.com/amdbouka/google-cloud-mlb-hackathon/blob/main/datasets/mlb-statsapi-docs/MLB-StatsAPI-Spec.json
+ */
+
+interface HitData {
+    launchSpeed: number;
+    launchAngle: number;
+    totalDistance: number;
+}
+
+interface PlayEventDetails {
+    description: string;
+    eventType: string;
+    event: string;
+    isInPlay: boolean;
+    isScoringPlay: boolean;
+    homeScore: number;
+    awayScore: number;
+    isOut: boolean;
+    hasReview?: boolean;
+}
+
+interface PlayEvent {
+    details: PlayEventDetails;
+    hitData: HitData;
+    playId: string;
+}
+
+interface PlayResult {
+    event: string;
+    eventType: string;
+    description: string;
+    homeScore: number;
+    awayScore: number;
+    isOut: boolean;
+}
+
+interface PlayAbout {
+    atBatIndex: number;
+    isComplete: boolean;
+    halfInning: string;
+    inning: number;
+    isScoringPlay: boolean;
+    hasReview: boolean;
+}
+
+interface PlayCount {
+    outs: number;
+    balls: number;
+    strikes: number;
+}
+
+interface PlayMatchup {
+    pitcher: { id: number; fullName: string };
+    batter: { id: number; fullName: string };
+    batSide: { code: string; description: string };
+}
+
+interface ReviewDetails {
+    inProgress: boolean;
+}
+
+/** At-bat from allPlays / currentPlay. */
+interface Play {
+    about: PlayAbout;
+    result: PlayResult;
+    count: PlayCount;
+    matchup: PlayMatchup;
+    playEvents: PlayEvent[];
+    atBatIndex: number;
+    reviewDetails: ReviewDetails;
+}
+
+interface LinescoreInning {
+    num: number;
+    away: { runs: number | string };
+    home: { runs: number | string };
+}
+
+interface LinescoreTeamStats {
+    runs: number;
+    hits: number;
+    errors: number;
+    leftOnBase: number;
+}
+
+interface LinescoreOffense {
+    battingOrder: number;
+    batter: { fullName: string };
+    onDeck: { fullName: string };
+    inHole: { fullName: string };
+}
+
+interface Linescore {
+    innings: LinescoreInning[];
+    teams: { away: LinescoreTeamStats; home: LinescoreTeamStats };
+    offense: LinescoreOffense;
+    currentInning: number;
+    currentInningOrdinal: string;
+    inningState: string;
+}
+
+interface BoxscorePlayerStats {
+    batting?: { summary: string };
+    pitching?: { summary: string; note: string; numberOfPitches: number; strikes: number };
+}
+
+interface BoxscorePlayer {
+    person: { id: number; fullName: string };
+    battingOrder: string; // e.g. "100", "101" for substitute
+    allPositions: Array<{ abbreviation: string; code: string }>;
+    stats: BoxscorePlayerStats;
+    gameStatus: { isSubstitute: boolean };
+}
+
+interface BoxscoreTeam {
+    team: { id: number; name: string; abbreviation: string };
+    players: Record<string, BoxscorePlayer>;
+    pitchers: number[];
+    batters: number[];
+}
+
+interface Boxscore {
+    teams: { away: BoxscoreTeam; home: BoxscoreTeam };
+}
+
+interface LiveFeedTeam {
+    id: number;
+    abbreviation: string;
+    name: string;
+    teamName?: string;
+    venue: { id: number; name: string };
+}
+
+interface AbsChallengeState { remaining: number; used: number }
+interface AbsChallenges { home: AbsChallengeState; away: AbsChallengeState }
+
+interface LiveFeedGameData {
+    game: { pk: number; type: string };
+    teams: { home: LiveFeedTeam; away: LiveFeedTeam };
+    players: Record<string, Person>; // keyed by "ID{personId}", e.g. "ID669257"
+    weather: { condition: string; temp: string; wind: string };
+    status: { abstractGameState: string; codedGameState: string; detailedState: string; statusCode: string; startTimeTBD: boolean };
+    datetime: { dateTime: string; officialDate: string };
+    venue: { id: number; name: string; fieldInfo?: { capacity: number } };
+    gameInfo?: { attendance?: number };
+    absChallenges?: AbsChallenges;
+}
+
+interface LiveFeedLiveData {
+    plays: { currentPlay: Play; allPlays: Play[]; scoringPlays: number[] };
+    linescore: Linescore;
+    boxscore: Boxscore;
+}
+
+interface LiveFeedResponse {
+    metaData: { timeStamp: string; gameEvents: string[]; logicalEvents: string[] };
+    gamePk: number;
+    gameData: LiveFeedGameData;
+    liveData: LiveFeedLiveData;
+}
+
+interface GameStatus {
+    abstractGameState: string;
+    codedGameState: string;
+    detailedState: string;
+    statusCode: string;
+    startTimeTBD: boolean;
+}
+
+interface ScheduleGameTeam {
+    team?: { id: number; abbreviation: string; name: string }; // present when hydrated
+    abbreviation?: string; // direct field when team hydration is absent
+    score?: number;
+    isWinner?: boolean;
+}
+
+interface ScheduleGame {
+    gamePk: number;
+    gameDate: string;
+    officialDate: string;
+    rescheduledFrom?: string;
+    status: GameStatus;
+    teams: { home: ScheduleGameTeam; away: ScheduleGameTeam };
+    gameType: string;
+    venue?: { id: number; name: string };
+    lineups?: {
+        homePlayers: Array<{ id: number; primaryPosition: { abbreviation: string } }>;
+        awayPlayers: Array<{ id: number; primaryPosition: { abbreviation: string } }>;
+    };
+}
+
+interface ScheduleDate { date: string; games: ScheduleGame[] }
+interface ScheduleResponse { dates: ScheduleDate[]; totalGames: number }
+
+interface StatSplitStat {
+    avg?: string; obp?: string; slg?: string; ops?: string;
+    homeRuns?: number; rbi?: number; stolenBases?: number;
+    plateAppearances?: number; atBats?: number; hits?: number;
+    doubles?: number; triples?: number;
+    era?: string; whip?: string; wins?: number; losses?: number;
+    gamesPlayed?: number; gamesStarted?: number; inningsPitched?: string;
+    strikeOuts?: number; baseOnBalls?: number; saves?: number; saveOpportunities?: number;
+    strikesoutsToWalks?: string; babip?: string; war?: number;
+    [key: string]: unknown;
+}
+
+interface StatSplit {
+    stat: StatSplitStat;
+    team?: object; // absent for overall (non-team-filtered) splits
+    split?: { code: string; description: string };
+    season?: string;
+}
+
+interface PersonStat {
+    type: { displayName: string };
+    group: { displayName: string };
+    splits: StatSplit[];
+}
+
+interface Person {
+    id: number;
+    fullName: string;
+    lastName?: string;
+    boxscoreName: string;
+    batSide: { code: string; description: string };
+    pitchHand: { code: string; description: string };
+    primaryPosition: { abbreviation: string; code: string; name: string };
+    currentTeam: { id: number; name?: string };
+    stats: PersonStat[];
+}
+
+interface PeopleResponse { people: Person[]; copyright?: string }
+
+interface SplitRecord { wins: number; losses: number; type: string; pct: string }
+
+interface TeamRecord {
+    team: { id: number; name: string; division: { id: number; name: string } };
+    leagueRecord: { wins: number; losses: number; pct: string };
+    wins: number; losses: number; pct: string;
+    gamesBack: string; wildCardGamesBack: string;
+    records: { splitRecords: SplitRecord[] };
+    streak: string | { streakCode: string };
+    standingsType?: string;
+    record_home?: string; record_away?: string; record_lastTen?: string; // bdfed endpoint only
+}
+
+/** One standings group (e.g. one division or the wildcard set). */
+interface StandingsRecord {
+    standingsType: string;
+    league?: number; // bdfed endpoint only
+    division?: { id: number };
+    teamRecords: TeamRecord[];
+}
+
+interface StandingsResponse { records: StandingsRecord[] }
+
+interface MatchupProbables {
+    homeProbable: number | null;
+    awayProbable: number | null;
+    homeAbbreviation: string;
+    awayAbbreviation: string;
+    gameType: string;
+}
+
+interface MatchupResponse { probables: MatchupProbables }
+
+interface DiffPatchDifference {
+    op: 'add' | 'replace' | 'remove' | 'copy' | 'move';
+    path: string;
+    value?: unknown;
+    from?: string;
+}
+
+interface DiffPatchResponse {
+    diff: DiffPatchDifference[];
+    timeStamp: string;
+    updateId: string;
+}
+
+interface SavantPlayMetrics {
+    play_id: string;
+    xba: string | null;
+    batSpeed: number | null;
+    is_barrel: 0 | 1;
+    contextMetrics?: { homeRunBallparks?: number };
+}
+
+interface SavantGameFeed { team_away: SavantPlayMetrics[]; team_home: SavantPlayMetrics[] }
+
+interface XParksEntry { id: number; name: string; team_abbrev: string }
+interface XParksResponse { hr: XParksEntry[]; not: XParksEntry[] }
+
+interface GamedaySocketEvent {
+    timeStamp: string;
+    updateId: string;
+    gamePk: number;
+    gameEvents: string[];
+    changeEvent?: { type: 'full_refresh' | 'diff_patch' };
+}
+


### PR DESCRIPTION
Introduced much improved data typing to make the codebase easier to work with. With MLB API objects/custom objects defined and JS docs added to functions, it will be much easier to track what data is being passed where and make the codebase more readable/maintainable

- jsconfig.json
Enables checkJs: true across the project with CommonJS + ES2022 settings

- types/mlb-api.d.ts
Ambient type declarations for every MLB Stats API shape used in the codebase (LiveFeedResponse, Play, PlayEvent, Linescore, Boxscore, ScheduleGame, Person, StandingsRecord, DiffPatchResponse, SavantGameFeed, etc.)

- types/custom.d.ts
Ambient type declarations for all custom objects (GameCache, GlobalCacheValues, LiveFeedWrapper, ProcessedPlay, MessageEntry, SavantQueueEntry, HydratedProbable, SavantMetric, ChannelSubscription, ReconnectingWebSocket, Logger, etc.)

- // ts-check + JSDoc on every export and key private function

**Testing**

In addition to all the unit tests still passing, audited each and every command that the bot has to verify they still work. Also subscribed to multiple live games to validate live game functionality still works