### PR TITLE
Fix edge case where an error thrown during diffpatch processing could leave the bot in a play processing loop

### DIFF
--- a/modules/gameday.js
+++ b/modules/gameday.js
@@ -133,8 +133,14 @@ function subscribe (bot, liveGame, games) {
                         try {
                             diffPatch.hydrate(patch);
                         } catch (e) {
-                            // catching something here means our game object could now be incorrect. reset the live feed.
+                            /*
+                                Catching something here means our game object could now be incorrect, so we fully
+                                reset the live feed. As a result of that, we should no longer be trying to apply
+                                the rest of the "patches" from this batch of updates, so we break out of the loop.
+                             */
                             globalCache.values.game.currentLiveFeed = await mlbAPIUtil.liveFeed(liveGame.gamePk);
+                            await reportPlays(bot, liveGame.gamePk);
+                            break;
                         }
                         await reportPlays(bot, liveGame.gamePk);
                     }


### PR DESCRIPTION
Very subtle issue here. If the diffpatch module throws an exception while applying json patches (literally the first time I've witnessed this happen), we fully reset the live feed since the live feed could now be wrong. However, **we were not breaking out of the loop** and instead applying the rest of the possibly outdated patches on top of that. This led us to be stuck with an outdated feed for a while:

<img width="540" alt="image" src="https://github.com/user-attachments/assets/d2651cbd-d74c-4094-ae11-662395eafabe" />

 We will now attempt to report plays after the full refresh and then break.