### PR TITLE
Make advanced stats optional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,6 @@ RUN npm install --only=production
 # Copy local code to the container image.
 COPY . ./
 
-# Run the web service on container startup.
-CMD [ "npm", "start" ]
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/commands/gameday_preference.js
+++ b/commands/gameday_preference.js
@@ -4,10 +4,10 @@ const { SlashCommandBuilder } = require('@discordjs/builders');
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('gameday_preference')
-        .setDescription('Change which plays the bot will report, or the reporting delay.')
+        .setDescription('Change the reporting delay, which plays the bot reports, and whether to include advanced stats.')
         .addBooleanOption(option =>
             option.setName('scoring_plays_only')
-                .setDescription('If true, the bot will only report scoring plays. Else, it reports at-bat results + other key events.')
+                .setDescription('Report only scoring plays?')
                 .setRequired(true))
         .addIntegerOption(option =>
             option.setName('reporting_delay')
@@ -15,7 +15,11 @@ module.exports = {
                 .setRequired(true)
                 .setMinValue(0)
                 .setMaxValue(180)
-        ),
+        )
+        .addBooleanOption(option =>
+            option.setName('advanced_stats')
+                .setDescription('Include advanced stats (xBA, HR/Park, Bat Speed) for balls in play?')
+                .setRequired(true)),
     async execute (interaction) {
         try {
             await interactionHandlers.gamedayPreferenceHandler(interaction);

--- a/commands/subscribe_gameday.js
+++ b/commands/subscribe_gameday.js
@@ -7,15 +7,19 @@ module.exports = {
         .setDescription('Subscribe this channel to live Gameday updates, including results of at-bats and other key events.')
         .addBooleanOption(option =>
             option.setName('scoring_plays_only')
-                .setDescription('If true, the bot will only report scoring plays. The default is false.')
+                .setDescription('Report only scoring plays? Defaults to false.')
                 .setRequired(false))
         .addIntegerOption(option =>
             option.setName('reporting_delay')
-                .setDescription('A number of seconds between 0 and 180')
+                .setDescription('A number of seconds between 0 and 180. Defaults to 0.')
                 .setRequired(false)
                 .setMinValue(0)
                 .setMaxValue(180)
-        ),
+        )
+        .addBooleanOption(option =>
+            option.setName('advanced_stats')
+                .setDescription('Include advanced stats (xBA, HR/Park, Bat Speed) for balls in play? Defaults to true.')
+                .setRequired(false)),
     async execute (interaction) {
         try {
             await interactionHandlers.subscribeGamedayHandler(interaction);

--- a/config/globals.js
+++ b/config/globals.js
@@ -372,6 +372,9 @@ module.exports = {
     CODED_GAME_STATES: {
         POSTPONED: 'D'
     },
+    PG_ERROR_CODES: {
+        UNDEFINED_COLUMN: '42703'
+    },
     /**
      * We enhanced the TEAM_ID variable to allow for a team name to be supplied instead
      * of a numeric ID, so the client doesn't have to look up the ID. The name is resolved

--- a/database/migrate.js
+++ b/database/migrate.js
@@ -8,8 +8,57 @@ const migrations = [
     'ALTER TABLE gameday_subscribe_channels ADD COLUMN IF NOT EXISTS advanced_stats BOOLEAN NOT NULL DEFAULT TRUE;'
 ];
 
+const maxAttempts = Number(process.env.DB_CONNECT_RETRIES || 15);
+const retryDelayMs = Number(process.env.DB_CONNECT_RETRY_MS || 2000);
+
+/**
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * @param {unknown} err
+ * @returns {boolean}
+ */
+function isTransientConnectionError(err) {
+    if (!err || typeof err !== 'object') {
+        return false;
+    }
+
+    const error = /** @type {{ code?: string, message?: string }} */ (err);
+    const message = (error.message || '').toLowerCase();
+
+    return error.code === 'ECONNREFUSED'
+        || error.code === 'ETIMEDOUT'
+        || message.includes('database system is starting up')
+        || message.includes('the database system is starting up')
+        || message.includes('connection terminated unexpectedly');
+}
+
 (async () => {
-    const client = await pool.connect();
+    let client;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+        try {
+            client = await pool.connect();
+            break;
+        } catch (e) {
+            const transient = isTransientConnectionError(e);
+            const canRetry = transient && attempt < maxAttempts;
+
+            if (!canRetry) {
+                console.error(`[migrate] Failed to connect after ${attempt} attempt(s):`, e.message);
+                process.exit(1);
+            }
+
+            console.error(`[migrate] DB not ready (attempt ${attempt}/${maxAttempts}). Retrying in ${retryDelayMs}ms...`);
+            await sleep(retryDelayMs);
+        }
+    }
+
     try {
         for (const sql of migrations) {
             await client.query(sql);
@@ -20,8 +69,9 @@ const migrations = [
         console.error('[migrate] Migration failed:', e.message);
         process.exit(1);
     } finally {
-        client.release();
+        if (client) {
+            client.release();
+        }
         await pool.end();
     }
 })();
-

--- a/database/migrate.js
+++ b/database/migrate.js
@@ -1,0 +1,27 @@
+// @ts-check
+'use strict';
+
+const pool = require('./db');
+
+const migrations = [
+    // v3.4.0
+    'ALTER TABLE gameday_subscribe_channels ADD COLUMN IF NOT EXISTS advanced_stats BOOLEAN NOT NULL DEFAULT TRUE;'
+];
+
+(async () => {
+    const client = await pool.connect();
+    try {
+        for (const sql of migrations) {
+            await client.query(sql);
+            console.log(`[migrate] OK: ${sql}`);
+        }
+        console.log('[migrate] All migrations applied.');
+    } catch (e) {
+        console.error('[migrate] Migration failed:', e.message);
+        process.exit(1);
+    } finally {
+        client.release();
+        await pool.end();
+    }
+})();
+

--- a/database/queries.js
+++ b/database/queries.js
@@ -7,7 +7,7 @@ module.exports = {
      */
     getAllSubscribedChannels: () => {
         return query({
-            text: 'SELECT channel_id, scoring_plays_only, delay FROM gameday_subscribe_channels;',
+            text: 'SELECT channel_id, scoring_plays_only, delay, advanced_stats FROM gameday_subscribe_channels;',
             values: []
         });
     },
@@ -17,12 +17,13 @@ module.exports = {
      * @param {string} channelId
      * @param {boolean} scoringPlaysOnly
      * @param {number} reportingDelay
+     * @param {boolean} advancedStats
      * @returns {Promise<any[]>}
      */
-    addToSubscribedChannels: (guildId, channelId, scoringPlaysOnly, reportingDelay) => {
+    addToSubscribedChannels: (guildId, channelId, scoringPlaysOnly, reportingDelay, advancedStats) => {
         return query({
-            text: 'INSERT INTO gameday_subscribe_channels VALUES ($1, $2, $3, $4);',
-            values: [guildId, channelId, scoringPlaysOnly, reportingDelay]
+            text: 'INSERT INTO gameday_subscribe_channels VALUES ($1, $2, $3, $4, $5);',
+            values: [guildId, channelId, scoringPlaysOnly, reportingDelay, advancedStats]
         });
     },
 
@@ -31,13 +32,14 @@ module.exports = {
      * @param {string} channelId
      * @param {boolean | null} scoringPlaysOnly
      * @param {number | null} reportingDelay
+     * @param {boolean | null} advancedStats
      * @returns {Promise<any[]>}
      */
-    updatePlayPreference: (guildId, channelId, scoringPlaysOnly, reportingDelay) => {
+    updatePlayPreference: (guildId, channelId, scoringPlaysOnly, reportingDelay, advancedStats) => {
         return query({
             text: 'UPDATE gameday_subscribe_channels SET scoring_plays_only' +
-                ' = $1, delay = $2 WHERE guild_id = $3 and channel_id = $4 RETURNING channel_id;',
-            values: [scoringPlaysOnly, reportingDelay, guildId, channelId]
+                ' = $1, delay = $2, advanced_stats = $3 WHERE guild_id = $4 and channel_id = $5 RETURNING channel_id;',
+            values: [scoringPlaysOnly, reportingDelay, advancedStats, guildId, channelId]
         });
     },
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,7 +1,12 @@
+-- version 3.4.0 introduced the advanced_stats column. To migrate existing deployments:
+-- ALTER TABLE gameday_subscribe_channels ADD COLUMN IF NOT EXISTS advanced_stats BOOLEAN NOT NULL DEFAULT TRUE;
+
+
 CREATE TABLE IF NOT EXISTS gameday_subscribe_channels(
     guild_id character varying(64) NOT NULL,
     channel_id character varying(64) NOT NULL,
-    scoring_plays_only BOOLEAN NOT NULL,
+    scoring_plays_only BOOLEAN NOT NULL DEFAULT FALSE,
     delay smallint NOT NULL,
+    advanced_stats BOOLEAN NOT NULL DEFAULT TRUE,
     PRIMARY KEY (guild_id, channel_id)
 );

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+echo "Running database migrations..."
+node database/migrate.js
+
+echo "Starting bot..."
+exec node main.js
+

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,5 +5,5 @@ echo "Running database migrations..."
 node database/migrate.js
 
 echo "Starting bot..."
-exec node main.js
+exec npm start
 

--- a/main.js
+++ b/main.js
@@ -6,7 +6,7 @@ const globalCache = require('./modules/global-cache');
 const queries = require('./database/queries');
 const commandUtil = require('./modules/command-util');
 const healthcheck = require('./modules/healthcheck');
-const { LOG_LEVEL } = require('./config/globals');
+const { LOG_LEVEL, PG_ERROR_CODES } = require('./config/globals');
 const globals = require('./config/globals');
 const LOGGER = require('./modules/logger')(process.env.LOG_LEVEL?.trim() || LOG_LEVEL.INFO);
 
@@ -40,7 +40,16 @@ BOT.once('ready', async () => {
         console.error(e);
         globalCache.values.emojis = [];
     }
-    globalCache.values.subscribedChannels = await queries.getAllSubscribedChannels();
+    try {
+        globalCache.values.subscribedChannels = await queries.getAllSubscribedChannels();
+    } catch (e) {
+        if (e.code === PG_ERROR_CODES.UNDEFINED_COLUMN) {
+            LOGGER.error('DB schema is out of date. Please run "npm run migrate" to safely update.');
+        } else {
+            LOGGER.error('Failed to load subscribed channels:', e);
+        }
+        process.exit(1);
+    }
     LOGGER.info('Subscribed channels: ' + JSON.stringify(globalCache.values.subscribedChannels, null, 2));
     commandUtil.buildPlayerCache().catch(e => LOGGER.error('Failed to build player cache:', e));
     healthcheck.start();

--- a/main.js
+++ b/main.js
@@ -44,7 +44,7 @@ BOT.once('ready', async () => {
         globalCache.values.subscribedChannels = await queries.getAllSubscribedChannels();
     } catch (e) {
         if (e.code === PG_ERROR_CODES.UNDEFINED_COLUMN) {
-            LOGGER.error('DB schema is out of date. Please run "npm run migrate" to safely update.');
+            LOGGER.error('DB schema is out of date. Please run "node database/migrate.js" to safely update (make sure the environment variables for the database are set).');
         } else {
             LOGGER.error('Failed to load subscribed channels:', e);
         }

--- a/modules/gameday.js
+++ b/modules/gameday.js
@@ -236,7 +236,7 @@ async function processAndPushPlay (bot, play, gamePk, atBatIndex, includeTitle =
         if (play.isComplete) {
             globalCache.values.game.lastReportedCompleteAtBatIndex = atBatIndex;
         }
-        const embed = gamedayUtil.constructPlayEmbed(
+        const embedWithStats = gamedayUtil.constructPlayEmbed(
             play,
             feed,
             includeTitle,
@@ -245,7 +245,30 @@ async function processAndPushPlay (bot, play, gamePk, atBatIndex, includeTitle =
             globalCache.values.game.homeTeamEmoji,
             globalCache.values.game.awayTeamEmoji
         );
-        const messages = [];
+        // For channels that opt out of advanced stats, strip "Pending..." placeholders from a separate embed copy.
+        const embedBasic = play.metricsAvailable
+            ? gamedayUtil.constructPlayEmbed(
+                play,
+                feed,
+                includeTitle,
+                globalCache.values.game.homeTeamColor,
+                globalCache.values.game.awayTeamColor,
+                globalCache.values.game.homeTeamEmoji,
+                globalCache.values.game.awayTeamEmoji
+            )
+            : embedWithStats;
+        if (play.metricsAvailable) {
+            embedBasic.data.description = embedBasic.data.description
+                .replaceAll('xBA: Pending...', '')
+                .replaceAll('Bat Speed: Pending...', '')
+                .replaceAll('HR/Park: Pending...', '')
+                .replace(/\n{3,}/g, '\n\n')
+                .trimEnd();
+        }
+        /** @type {MessageEntry[]} */
+        const advancedStatsMessages = [];
+        /** @type {MessageEntry[]} */
+        const allMessages = [];
         for (const channelSubscription of globalCache.values.subscribedChannels) {
             let returnedChannel;
             try {
@@ -258,7 +281,8 @@ async function processAndPushPlay (bot, play, gamePk, atBatIndex, includeTitle =
             if (!play.isScoringPlay && channelSubscription.scoring_plays_only) {
                 LOGGER.debug('Skipping - against the channel\'s preference');
             } else {
-                const message = { channel: returnedChannel, play, delayed: false, doneEditing: false };
+                const embed = channelSubscription.advanced_stats ? embedWithStats : embedBasic;
+                const message = { channel: returnedChannel, play, delayed: false, doneEditing: !channelSubscription.advanced_stats };
                 if (channelSubscription.delay === 0 || play.isStartEvent) {
                     await module.exports.sendMessage(returnedChannel, embed, message);
                 } else {
@@ -266,11 +290,14 @@ async function processAndPushPlay (bot, play, gamePk, atBatIndex, includeTitle =
                     message.delayed = true;
                     sendDelayedMessage(play, gamePk, channelSubscription, returnedChannel, embed, message);
                 }
-                messages.push(message);
+                allMessages.push(message);
+                if (channelSubscription.advanced_stats) {
+                    advancedStatsMessages.push(message);
+                }
             }
         }
-        if (messages.length > 0) {
-            await maybePopulateAdvancedStatcastMetrics(play, messages, gamePk, embed);
+        if (advancedStatsMessages.length > 0) {
+            await maybePopulateAdvancedStatcastMetrics(play, advancedStatsMessages, gamePk, embedWithStats);
         }
     }
 }

--- a/modules/interaction-handlers.js
+++ b/modules/interaction-handlers.js
@@ -205,12 +205,14 @@ module.exports = {
         await interaction.deferReply();
         const scoringPlaysOnly = interaction.options.getBoolean('scoring_plays_only');
         const reportingDelay = interaction.options.getInteger('reporting_delay');
+        const advancedStats = interaction.options.getBoolean('advanced_stats');
         if (interaction.channel) {
             await queries.addToSubscribedChannels(
                 interaction.guild.id,
                 interaction.channel.id,
                 scoringPlaysOnly || false,
-                reportingDelay || 0
+                reportingDelay || 0,
+                advancedStats ?? true
             ).catch(async (e) => {
                 if (e.message.includes('duplicate key')) {
                     await interaction.followUp({
@@ -234,7 +236,8 @@ module.exports = {
                 ephemeral: false,
                 content: 'Subscribed this channel to the gameday feed.\n' +
                     'Events: ' + (scoringPlaysOnly ? '**Scoring Plays Only**' : '**All Plays**') + '\n' +
-                    'Reporting Delay: **' + (reportingDelay || 0) + ' seconds**'
+                    'Reporting Delay: **' + (reportingDelay || 0) + ' seconds**\n' +
+                    'Advanced Stats (xBA, HR/Park, Bat Speed): **' + ((advancedStats ?? true) ? 'Enabled' : 'Disabled') + '**'
             });
         }
     },
@@ -302,12 +305,14 @@ module.exports = {
         await interaction.deferReply();
         const scoringPlaysOnly = interaction.options.getBoolean('scoring_plays_only');
         const reportingDelay = interaction.options.getInteger('reporting_delay');
+        const advancedStats = interaction.options.getBoolean('advanced_stats');
         if (interaction.channel) {
             await queries.updatePlayPreference(
                 interaction.guild.id,
                 interaction.channel.id,
                 scoringPlaysOnly,
-                reportingDelay
+                reportingDelay,
+                advancedStats ?? true
             )
                 .then(async (rows) => {
                     if (rows.length === 0) {
@@ -333,7 +338,8 @@ module.exports = {
                 ephemeral: false,
                 content: 'Updated this channel\'s Gameday play reporting preferences:\n' +
                     'Events: ' + (scoringPlaysOnly ? '**Scoring Plays Only**' : '**All Plays**') + '\n' +
-                    'Reporting Delay: **' + (reportingDelay || 0) + ' seconds**'
+                    'Reporting Delay: **' + (reportingDelay || 0) + ' seconds**\n' +
+                    'Advanced Stats (xBA, HR/Park, Bat Speed): **' + ((advancedStats ?? true) ? 'Enabled' : 'Disabled') + '**'
             });
         }
     },

--- a/modules/logger.js
+++ b/modules/logger.js
@@ -1,36 +1,45 @@
 // @ts-check
 const { LOG_LEVEL } = require('../config/globals');
 
+const RESET = '\x1b[0m';
+const COLORS = {
+    info: '\x1b[34m', // blue
+    error: '\x1b[31m', // red
+    warn: '\x1b[33m', // yellow
+    debug: '\x1b[36m', // cyan
+    trace: '\x1b[35m' // magenta
+};
+
+/** @param {string} level @param {string} label */
+function prefix (level, label) {
+    return `${COLORS[level]}${label}${RESET}`;
+}
+
 /** @returns {Logger} */
 module.exports = function (logLevel = LOG_LEVEL.INFO) {
     return {
         logLevel,
         info (message = '') {
             const now = new Date();
-            console.log('LOG   ', now.toGMTString(), ': ', message);
+            console.log(prefix('info', 'LOG   '), now.toGMTString(), ': ', message);
         },
 
         error (message = '') {
-            if (
-                logLevel === LOG_LEVEL.INFO
-            ) { return; }
+            if (logLevel === LOG_LEVEL.INFO) { return; }
             const now = new Date();
-            console.error('ERROR ', now.toGMTString(), ': ', message);
+            console.error(prefix('error', 'ERROR '), now.toGMTString(), ': ', message);
         },
 
         warn (message = '') {
-            if (
-                logLevel === LOG_LEVEL.INFO
-                    || logLevel === LOG_LEVEL.ERROR
-            ) return;
+            if (logLevel === LOG_LEVEL.INFO || logLevel === LOG_LEVEL.ERROR) return;
             const now = new Date();
-            console.warn('WARN ', now.toGMTString(), ': ', message);
+            console.warn(prefix('warn', 'WARN  '), now.toGMTString(), ': ', message);
         },
 
         debug (message = '') {
             if (logLevel === LOG_LEVEL.INFO || logLevel === LOG_LEVEL.ERROR || logLevel === LOG_LEVEL.WARN) return;
             const now = new Date();
-            console.debug('DEBUG ', now.toGMTString(), ': ', message);
+            console.debug(prefix('debug', 'DEBUG '), now.toGMTString(), ': ', message);
         },
 
         trace (message = '') {
@@ -40,9 +49,8 @@ module.exports = function (logLevel = LOG_LEVEL.INFO) {
                     || logLevel === LOG_LEVEL.DEBUG
                     || logLevel === LOG_LEVEL.ERROR
             ) return;
-
             const now = new Date();
-            console.log('TRACE ', now.toGMTString(), ': ', message);
+            console.log(prefix('trace', 'TRACE '), now.toGMTString(), ': ', message);
         }
     };
 };

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "main.js",
   "scripts": {
     "test": "jasmine",
+    "migrate": "node database/migrate.js",
     "start": "NODE_ENV=production && node deploy-commands.js && node main.js",
     "start:dev": "SET NODE_ENV=development && node deploy-commands.js && node main.js"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "main.js",
   "scripts": {
     "test": "jasmine",
-    "migrate": "node database/migrate.js",
     "start": "NODE_ENV=production && node deploy-commands.js && node main.js",
     "start:dev": "SET NODE_ENV=development && node deploy-commands.js && node main.js"
   },

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -6,6 +6,7 @@ interface ChannelSubscription {
     channel_id: string;
     scoring_plays_only: boolean;
     delay: number; // seconds
+    advanced_stats: boolean;
 }
 
 interface GameCache {


### PR DESCRIPTION
in case clients would prefer not to have the advanced "baseball savant" stats listed for all balls in play, we've added a column to the database schema and a corresponding option to the gameday subscription commands to specify whether these  stats should be included.

In case clients pull down this version but don't update the database, I've added detailed messaging specifying that the schema needs updated. Anyone that uses the Dockerfile will get the changes automatically.

Also added coloring to log statements based on the log level.

**Disabled:**

<img width="561" height="179" alt="image" src="https://github.com/user-attachments/assets/6204f11f-2b83-4cf9-8ea5-fb36da57b928" />

**Enabled**:
<img width="578" height="239" alt="image" src="https://github.com/user-attachments/assets/eeef2270-43b0-46db-8896-a853468ab96f" />

